### PR TITLE
Add initial BinWrite trait proposal

### DIFF
--- a/binrw/src/binwrite.rs
+++ b/binrw/src/binwrite.rs
@@ -17,13 +17,10 @@ pub trait BinWrite {
     ///
     /// # Panics
     /// Panics if there is no [`args_default`](BinWrite::args_default) implementation
-    fn write<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()> {
-        let args = match Self::args_default() {
-            Some(args) => args,
-            None => panic!("Must pass args, no args_default implemented")
-        };
-
-        self.write_options(writer, &WriteOptions::default(), args)
+    fn write<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
+        where Self::Args: Default
+    {
+        self.write_options(writer, &WriteOptions::default(), Self::Args::default())
     }
 
     /// Write the type to a writer while providing the default options
@@ -39,18 +36,4 @@ pub trait BinWrite {
         options: &WriteOptions,
         args: Self::Args,
     ) -> BinResult<()>;
-
-    /// The default arguments to be used when using the [`write`](BinWrite::write) shortcut method.
-    /// Override this for any type that optionally requries arguments
-    fn args_default() -> Option<Self::Args> {
-        // Trick to effectively get specialization on stable, should constant-folded away
-        // Returns `Some(())` if Self::Args == (), otherwise returns `None`
-        let mut args = None::<Self::Args>;
-
-        if let Some(args) = Any::downcast_mut::<Option<()>>(&mut args) {
-            args.replace(());
-        }
-
-        args
-    }
 }

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -149,7 +149,10 @@ pub use {
         FilePtr64,
         FilePtr128,
     },
-    options::ReadOptions,
+    options::{
+        ReadOptions,
+        WriteOptions
+    },
     strings::{
         NullString,
         NullWideString
@@ -167,6 +170,9 @@ pub use binread_impls::*;
 
 mod binread;
 pub use binread::*;
+
+mod binwrite;
+pub use binwrite::*;
 
 /// The collection of traits and types you'll likely need when working with binread and are
 /// unlikely to cause name conflicts.

--- a/binrw/src/options.rs
+++ b/binrw/src/options.rs
@@ -1,4 +1,4 @@
-use super::Endian;
+use crate::Endian;
 
 /// Runtime-configured options for reading the type using [`BinRead`](BinRead)
 #[non_exhaustive]
@@ -7,4 +7,28 @@ pub struct ReadOptions {
     pub endian: Endian,
     pub count: Option<usize>,
     pub offset: u64,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct WriteOptions {
+    endian: Endian,
+}
+
+impl WriteOptions {
+    pub fn new() -> Self {
+        Self {
+            endian: Endian::Native
+        }
+    }
+
+    pub fn with_endian(self, endian: Endian) -> Self {
+        Self {
+            endian,
+            ..self
+        }
+    }
+
+    pub fn endian(&self) -> Endian {
+        self.endian
+    }
 }


### PR DESCRIPTION
This is very much an initial trait design. It's a lot more based on the current state of BinRead than it is actually what I want to look like. Just want to get the ball rolling on the design.

Some notable possible problems:
* Args here is likely going to need to be reworked to fit whatever our end decision on #5 is
* Seek bound issue still needs to be figured out (#6)

```rust
pub trait BinWrite {
    /// The type of arguments needed to be supplied in order to write this type, usually a tuple.
    ///
    /// **NOTE:** For types that don't require any arguments, use the unit (`()`) type. This will allow [`read`](BinRead::read) to be used.
    type Args: Any + Copy;


    /// Write a type to a writer while assuming no arguments are needed.
    ///
    /// # Panics
    /// Panics if there is no [`args_default`](BinWrite::args_default) implementation
    fn write<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
        where Self::Args: Default
    {
        self.write_options(writer, &WriteOptions::default(), Self::Args::default())
    }

    /// Write the type to a writer while providing the default options
    fn write_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args) -> BinResult<()> {
        self.write_options(writer, &WriteOptions::default(), args)
    }

    /// Write the type to a writer, given the options on how to write it and the type-specific
    /// arguments
    fn write_options<W: Write + Seek>(
        &self,
        writer: &mut W,
        options: &WriteOptions,
        args: Self::Args,
    ) -> BinResult<()>;
}
```