### PR TITLE
Improve error output, especially for custom errors

### DIFF
--- a/binrw/src/attribute.rs
+++ b/binrw/src/attribute.rs
@@ -219,6 +219,11 @@
 //! # use binrw::{prelude::*, io::Cursor};
 //! #[derive(Debug, PartialEq)]
 //! struct NotSmallerError(u32, u32);
+//! impl core::fmt::Display for NotSmallerError {
+//!     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//!         write!(f, "{} <= {}", self.0, self.1)
+//!     }
+//! }
 //!
 //! #[derive(BinRead, Debug)]
 //! #[br(assert(some_val > some_smaller_val, NotSmallerError(some_val, some_smaller_val)))]

--- a/binrw/src/io/no_std/error.rs
+++ b/binrw/src/io/no_std/error.rs
@@ -10,6 +10,12 @@ impl fmt::Debug for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self, f)
+    }
+}
+
 #[derive(Debug)]
 enum Repr {
     Simple(ErrorKind),

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String};
-use crate::{BinRead, BinResult, Error, ReadOptions, io};
+use crate::{BinRead, BinResult, Error, ReadOptions, error::CustomError, io};
 
 pub enum AssertErrorFn<M, E> {
     Message(M),
@@ -12,7 +12,7 @@ where
     MsgFn: Fn() -> Msg,
     Msg: Into<String> + Sized,
     ErrorFn: Fn() -> Err,
-    Err: core::any::Any + Sync + Send + 'static,
+    Err: CustomError,
 {
     if test {
         Ok(())

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -76,6 +76,11 @@ fn assert() {
 fn assert_custom_err() {
     #[derive(Debug)]
     struct Oops(u8);
+    impl core::fmt::Display for Oops {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "oops!")
+        }
+    }
 
     #[derive(BinRead, Debug)]
     struct Test {
@@ -85,6 +90,7 @@ fn assert_custom_err() {
 
     Test::read(&mut Cursor::new("\x01")).unwrap();
     let error = Test::read(&mut Cursor::new("\x02")).expect_err("accepted bad data");
+    assert_eq!(format!("{}", error), "oops! at 0x0");
     let error = error.custom_err::<Oops>().expect("bad error type");
     assert_eq!(error.0, 2);
 }

--- a/binrw/tests/derive/struct_map.rs
+++ b/binrw/tests/derive/struct_map.rs
@@ -76,7 +76,13 @@ fn try_map_struct() {
         a: i16,
     }
 
+    #[derive(Debug)]
     struct Oops;
+    impl core::fmt::Display for Oops {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            core::fmt::Debug::fmt(self, f)
+        }
+    }
 
     impl Test {
         fn from_bytes(bytes: [u8; 2]) -> Result<Self, Oops> {

--- a/binrw_derive/src/codegen/read_options.rs
+++ b/binrw_derive/src/codegen/read_options.rs
@@ -104,13 +104,14 @@ impl <'input> PreludeGenerator<'input> {
 fn get_assertions(assertions: &[Assert]) -> impl Iterator<Item = TokenStream> + '_ {
     assertions.iter().map(|Assert { condition, consequent }| {
         let error_fn = match &consequent {
-            Some(AssertionError::Message(message)) =>
-                quote! { #ASSERT_ERROR_FN::<_, fn() -> ()>::Message(|| { #message }) },
+            Some(AssertionError::Message(message)) => {
+                quote! { #ASSERT_ERROR_FN::<_, fn() -> !>::Message(|| { #message }) }
+            },
             Some(AssertionError::Error(error)) =>
                 quote! { #ASSERT_ERROR_FN::Error::<fn() -> &'static str, _>(|| { #error }) },
             None => {
                 let condition = condition.to_string();
-                quote! { #ASSERT_ERROR_FN::Message::<_, fn() -> ()>(|| { #condition }) }
+                quote! { #ASSERT_ERROR_FN::Message::<_, fn() -> !>(|| { #condition }) }
             },
         };
 


### PR DESCRIPTION
This is a breaking change because it requires errors to implement
Display and Debug, but this is also the case for std::error::Error
so this should not be a problem for nearly every error type a user
will try to use.

It also requires magic to implement Debug, but magic must be a
primitive and all primitives implement Debug anyway so this part
is not a breaking change (though the output for byte arrays might
not be especially beautiful).

Refs jam1garner/binrw#9.