### PR TITLE
Add `dbg` directive

### DIFF
--- a/binrw/src/attribute.rs
+++ b/binrw/src/attribute.rs
@@ -13,6 +13,7 @@
 //! | [`big`](#byte-order) | all except unit variant | Sets the byte order to big-endian.
 //! | [`calc`](#calculations) | field | Computes the value of a field instead of reading data.
 //! | [`count`](#count) | field | Sets the length of a vector.
+//! | [`dbg`](#debug) | field | Prints out the parsed value and offset to help debug
 //! | [`default`](#default) | field | Uses the [`default`](core::default::Default) value for a field instead of reading data.
 //! | [`deref_now`](#postprocessing) | field | An alias for `postprocess_now`.
 //! | [`if`](#conditional-values) | field | Reads data only if a condition is true.
@@ -643,6 +644,31 @@
 //!
 //! # let val: MyType = Cursor::new(b"\0\0\0\x04Test\0").read_be().unwrap();
 //! # assert_eq!(val.some_string.to_string(), "Test");
+//! ```
+//!
+//! # Debug
+//!
+//! The `dbg` directive prints out information to stderr to help with quick-and-dirty debugging.
+//!
+//! The information printed out:
+//! * Source filename
+//! * Line number in source file
+//! * Offset in reader (in hex)
+//! * Contents of parsed value (using hex format when available)
+//!
+//! ```ignore
+//! #[derive(BinRead)]
+//! struct DbgExample {
+//!     first_value: u32,
+//!     #[br(dbg)]
+//!     second_value: u32,
+//! }
+//! ```
+//!
+//! Which will output something like...
+//!
+//! ```text
+//! [src/main.rs:5 | offset 0x4] second_value = 0xFFFE76
 //! ```
 //!
 //! # Calculations

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -49,3 +49,17 @@ pub fn try_after_parse<Reader, ValueType, ArgType>(
 
     Ok(())
 }
+
+#[cfg(feature = "std")]
+pub use std::eprintln;
+
+#[cfg(not(feature = "std"))]
+#[doc(hidden)]
+#[macro_export] macro_rules! eprintln {
+    ($($tt:tt)*) => {
+        compile_error!("dbg requires feature `std`")
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub use crate::eprintln;

--- a/binrw/tests/derive/structs.rs
+++ b/binrw/tests/derive/structs.rs
@@ -376,3 +376,21 @@ fn tuple_calc_temp_field() {
     // compilation would fail if it weren’t due to missing a second item
     assert_eq!(result, Test(5u32));
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn debug() {
+    #[allow(dead_code)]
+    #[derive(BinRead)]
+    struct Test {
+        before: u16,
+        #[br(dbg, big)]
+        value: u32,
+    }
+
+    let _ = Test::read(&mut Cursor::new(b"\0\0\0\0\0\x04")).unwrap();
+
+    // outputs:
+    //
+    // [binrw/tests/derive/structs.rs:383 | offset 0x2] value = 0x4
+}

--- a/binrw/tests/ui/invalid_keyword_struct_field.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct_field.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
  --> $DIR/invalid_keyword_struct_field.rs:5:10
   |
 5 |     #[br(invalid_struct_field_keyword)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -4,13 +4,13 @@ error: expected one of: `big`, `little`, `map`, `try_map`, `magic`, `import`, `i
 6 | #[br(invalid_keyword_struct)]
   |      ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
  --> $DIR/non_blocking_errors.rs:8:10
   |
 8 |     #[br(invalid_keyword_struct_field_a)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_tuple`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
   --> $DIR/non_blocking_errors.rs:10:10
    |
 10 |     #[br(invalid_keyword_struct_field_b)]

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -45,6 +45,7 @@ ident_str! {
     pub(super) ASSERT_ERROR_FN = from_crate!(__private::AssertErrorFn);
     pub(super) COERCE_FN = from_crate!(__private::coerce_fn);
     pub(super) TRY_AFTER_PARSE = from_crate!(__private::try_after_parse);
+    pub(super) DBG_EPRINTLN = from_crate!(__private::eprintln);
     pub(super) TEMP = "__binrw_temp";
     pub(super) POS = "__binrw_generated_position_temp";
     pub(super) ERROR_BASKET = "__binrw_generated_error_basket";

--- a/binrw_derive/src/parser/attrs.rs
+++ b/binrw_derive/src/parser/attrs.rs
@@ -37,3 +37,4 @@ pub(crate) type SeekBefore = MetaExpr<kw::seek_before>;
 pub(crate) type Temp = kw::temp;
 pub(crate) type Try = Token![try];
 pub(crate) type TryMap = MetaExpr<kw::try_map>;
+pub(crate) type Debug = kw::dbg;

--- a/binrw_derive/src/parser/field_level_attrs.rs
+++ b/binrw_derive/src/parser/field_level_attrs.rs
@@ -49,6 +49,8 @@ attr_struct! {
         pub(crate) seek_before: Option<TokenStream>,
         #[from(PadSizeTo)]
         pub(crate) pad_size_to: Option<TokenStream>,
+        #[from(Debug)]
+        pub (crate) debug: bool,
     }
 }
 
@@ -104,6 +106,7 @@ impl FromField for StructField {
             align_after: <_>::default(),
             seek_before: <_>::default(),
             pad_size_to: <_>::default(),
+            debug: <_>::default(),
         }, &field.attrs);
 
         match result {

--- a/binrw_derive/src/parser/keywords.rs
+++ b/binrw_derive/src/parser/keywords.rs
@@ -42,4 +42,5 @@ define_keywords! {
     seek_before,
     temp,
     try_map,
+    dbg,
 }


### PR DESCRIPTION
Purely out of curiosity of how an implementation would feel, I implemented a `dbg` directive.

To explain, here's the documentation for it:

---

The `dbg` directive prints out information to stderr to help with quick-and-dirty debugging.
                                                                                            
The information printed out:
* Source filename
* Line number in source file
* Offset in reader (in hex)
* Contents of parsed value (using hex format when available)
                                                                                            
```rust
#[derive(BinRead)]
struct DbgExample {
    first_value: u32,
    #[br(dbg)]
    second_value: u32,
}
```
                                                                                            
Which will output something like...
                                                                                            
```text
[src/main.rs:5 | offset 0x4] second_value = 0xFFFE76
```

---

This is not necessarily something we need to add, just putting this here to (a) collect thoughts and (b) have an implementation if ever desired.