### PR TITLE
Print FilePtr pointer value in Debug output

### DIFF
--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -131,7 +131,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, BR: BinRead> FilePtr<Ptr, BR> {
 
 /// A trait to convert from an integer into
 /// [`SeekFrom::Current`](crate::io::SeekFrom::Current).
-pub trait IntoSeekFrom: Copy {
+pub trait IntoSeekFrom: Copy + fmt::Debug {
     /// Converts the value.
     fn into_seek_from(self) -> SeekFrom;
 }
@@ -191,7 +191,7 @@ where
         if let Some(ref value) = self.value {
             fmt::Debug::fmt(value, f)
         } else {
-            write!(f, "UnreadPointer")
+            f.debug_tuple("UnreadPointer").field(&self.ptr).finish()
         }
     }
 }


### PR DESCRIPTION
Makes debug output more helpful when working with unparsed `FilePtr`s during development. (This might get shuffled around if `FilePtr` gets reworked, but it's a small yet meaningful change nonetheless.)

`fmt::Debug` is placed as a bound on `IntoSeekFrom` as opposed to `FilePtr`'s `Debug` impl, since one would hope an integral type also has one.

This is my first time doing a `Debug` impl, let me know if it's messy.