### PR TITLE
Questionable backwards-incompatible changes

### DIFF
--- a/binrw/src/binread.rs
+++ b/binrw/src/binread.rs
@@ -28,7 +28,7 @@ pub type BinResult<T> = core::result::Result<T, Error>;
 /// [temporary fields].
 ///
 /// [temporary fields]: crate::attribute#temp
-pub trait BinRead: Sized + 'static {
+pub trait BinRead: Sized {
     /// The type used for the `args` parameter of [`read_args()`] and
     /// [`read_options()`].
     ///

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -48,6 +48,23 @@ where
     f
 }
 
+pub fn magic<R, B>(reader: &mut R, expected: B, options: &ReadOptions) -> BinResult<()>
+where
+    B: BinRead<Args = ()> + core::fmt::Debug + PartialEq + Sync + Send + 'static,
+    R: io::Read + io::Seek,
+{
+    let pos = reader.seek(io::SeekFrom::Current(0))?;
+    let val = B::read_options(reader, &options, ())?;
+    if val == expected {
+        Ok(())
+    } else {
+        Err(Error::BadMagic {
+            pos,
+            found: Box::new(val) as _,
+        })
+    }
+}
+
 pub fn try_after_parse<Reader, ValueType, ArgType>(
     item: &mut Option<ValueType>,
     reader: &mut Reader,

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -46,7 +46,7 @@ ident_str! {
     pub(super) OPT = "__binrw_generated_var_options";
     pub(super) ARGS = "__binrw_generated_var_arguments";
     pub(super) SAVED_POSITION = "__binrw_generated_saved_position";
-    pub(super) ASSERT_MAGIC = from_crate!(error::magic);
+    pub(super) ASSERT_MAGIC = from_crate!(__private::magic);
     pub(super) ASSERT = from_crate!(__private::assert);
     pub(super) ASSERT_ERROR_FN = from_crate!(__private::AssertErrorFn);
     pub(super) COERCE_FN = from_crate!(__private::coerce_fn);


### PR DESCRIPTION
Opening this for a short discussion. (To be clear, the questionable changes are the ones I wrote in this PR, not referring to any other code.)

The first commit moves away some APIs that were in the error module. I’m not sure if anyone actually uses these or not. It seems like they may have been intended entirely for the derive. @jam1garner do you remember anything about these? Is there a reason why they should not be moved/removed like this?

The second commit is about the fake specialisation mechanism added for `Vec<u8>`. I only noticed this problem because after switching to binrw I had a new compiler error because a generic type I’d created which accepted a `BinRead` was not also restricted to the `'static` lifetime. It’s possible to reduce the scope of the lifetime requirement by applying it only to the `Vec<B>` implementation, which is what this commit does, but I’m not sure if this is actually better or not. It does follow some principle of least constraint, but ideally there would not need to be any static lifetime restriction here at all, and having it only on `Vec<B>` seems like it could be surprising. I’m not sure if there is any safe way of avoiding it since `Any` has the `'static` requirement so that downcast call can’t happen otherwise. Could you maybe start by sharing some actual performance benchmarks for this fake specialisation (when using a BufRead)? That would help me to decide where I land on its existence.