### PR TITLE
Make binrw accessible from the derive macro when used in binrw.

### DIFF
--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -124,6 +124,13 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 
+// binrw_derive expects to be able to access items in binrw via
+// `::binrw::<whatever>`. Normally, this would fail in this crate
+// because binrw knows of no crate called "binrw".
+// This causes binrw to associate *itself* as binrw,
+// meaning it makes access via ::binrw work.
+extern crate self as binrw;
+
 #[cfg(feature = "std")]
 use std as alloc;
 

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -129,6 +129,7 @@
 // because binrw knows of no crate called "binrw".
 // This causes binrw to associate *itself* as binrw,
 // meaning it makes access via ::binrw work.
+#[allow(unused_extern_crates)]
 extern crate self as binrw;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
As discussed in discord. I have tested it, it seems to work as intended.