### PR TITLE
Add support for adding context to errors

### DIFF
--- a/binrw/tests/error.rs
+++ b/binrw/tests/error.rs
@@ -31,3 +31,94 @@ fn custom_error_trait() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn context() {
+    use binrw::error::Context;
+    use std::error::Error as StdError;
+
+    #[derive(Debug)]
+    struct Oops;
+    impl core::fmt::Display for Oops {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Oops")
+        }
+    }
+    impl StdError for Oops {}
+
+    #[derive(Debug)]
+    struct BigYikes;
+    impl core::fmt::Display for BigYikes {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Big yikes")
+        }
+    }
+    impl StdError for BigYikes {}
+
+    let err = Error::Custom {
+        pos: 0xf,
+        err: Box::new(Oops),
+    };
+
+    assert!(err.source().is_none());
+
+    let context_err = Err::<(), Error>(err)
+        .context(|| "goofed".to_string())
+        .unwrap_err();
+    assert!(matches!(context_err, Error::Context { .. }));
+    assert_eq!(
+        context_err.custom_err::<String>(),
+        Some(&"goofed".to_string())
+    );
+    assert!(matches!(context_err.custom_err::<Oops>(), Some(&Oops)));
+
+    if let Some(Error::Custom { pos, err }) = context_err.source() {
+        assert_eq!(*pos, 0xf);
+        assert!(matches!(err.downcast_ref::<Oops>(), Some(&Oops)));
+    } else {
+        panic!("bad error returned from error source: {:?}", context_err);
+    }
+
+    #[cfg(feature = "std")]
+    {
+        let std_err = StdError::source(&context_err).and_then(|err| err.downcast_ref::<Error>());
+        if let Some(Error::Custom { pos, err }) = std_err {
+            assert_eq!(*pos, 0xf);
+            assert!(matches!(err.downcast_ref::<Oops>(), Some(&Oops)));
+        } else {
+            panic!("bad error returned from std source: {:?}", std_err);
+        }
+    }
+
+    let context_err = context_err.context(BigYikes);
+
+    let display = format!("{}", context_err);
+    assert!(display.contains("Big yikes"));
+    assert!(display.contains("goofed"));
+    assert!(display.contains("Oops"));
+    assert!(display.contains("0xf"));
+}
+
+#[test]
+fn std_context() {
+    use binrw::error::Context;
+
+    #[derive(Debug)]
+    struct Oops;
+    impl core::fmt::Display for Oops {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Oops")
+        }
+    }
+
+    let err = Error::Custom {
+        pos: 0xf,
+        err: Box::new(Oops),
+    };
+
+    let context_err = Err::<(), Error>(err)
+        .context(|| "lol".to_string())
+        .unwrap_err();
+    assert_eq!(context_err.custom_err::<String>(), Some(&"lol".to_string()));
+    assert!(matches!(context_err.custom_err::<Oops>(), Some(&Oops)));
+}


### PR DESCRIPTION
Refs jam1garner/binrw#9.

Outstanding questions on my mind:

1. Should the API be closer to e.g. `anyhow` (to be familiar)? Further away (to avoid conflicts)? I went with `context` + closure because (a) `with_context` when using `anyhow` is more common than `context` alone, in my experience, and so this is less typing in the common case, and (b) there’s no chance of someone accidentally running a heavy function for error in the success path.
2. How should this trait be exposed for users? In the root of the crate? Right now it is accessible only from `binrw::error::Context`, which I feel is OK, but I don’t know.
3. Is the error output OK?
4. Should it be Sealed?
5. Should this API be used as-is to describe errors from derived fields? Should a more specific variant (which would potentially allow one less heap allocation) be used instead for this case?
6. Should there be some `#[br(context = "you donked it")]` for fields and/or top-level?