### PR TITLE
Drop imports when generating enum variants

### DIFF
--- a/binrw/tests/derive/enum.rs
+++ b/binrw/tests/derive/enum.rs
@@ -19,6 +19,25 @@ fn enum_assert() {
 }
 
 #[test]
+fn enum_non_copy_args() {
+    #[derive(BinRead, Debug)]
+    #[br(import(a: NonCopyArg))]
+    enum Test {
+        A {
+            #[br(calc = a.0)]
+            a: u8,
+        },
+        B {
+            #[br(calc = a.0)]
+            b: u8,
+        },
+    }
+
+    #[derive(Clone)]
+    struct NonCopyArg(u8);
+}
+
+#[test]
 fn enum_calc_temp_field() {
     #[derive_binread]
     #[derive(Debug, Eq, PartialEq)]

--- a/binrw_derive/src/codegen/read_options/enum.rs
+++ b/binrw_derive/src/codegen/read_options/enum.rs
@@ -5,7 +5,9 @@ use super::{
 };
 #[allow(clippy::wildcard_imports)]
 use crate::codegen::sanitization::*;
-use crate::parser::{Enum, EnumErrorMode, EnumVariant, Input, UnitEnumField, UnitOnlyEnum};
+use crate::parser::{
+    Enum, EnumErrorMode, EnumVariant, Imports, Input, UnitEnumField, UnitOnlyEnum,
+};
 use proc_macro2::TokenStream;
 use quote::quote;
 
@@ -154,7 +156,10 @@ pub(super) fn generate_data_enum(input: &Input, en: &Enum) -> TokenStream {
 fn generate_variant_impl(en: &Enum, variant: &EnumVariant) -> TokenStream {
     // TODO: Kind of expensive since the enum is containing all the fields
     // and this is a clone.
-    let input = Input::Enum(en.with_variant(variant));
+    let mut new_enum = en.with_variant(variant);
+    // Drop imports, we already have them in scope
+    new_enum.imports = Imports::None;
+    let input = Input::Enum(new_enum);
 
     match variant {
         EnumVariant::Variant { ident, options } => StructGenerator::new(&input, &options)


### PR DESCRIPTION
This fixes using a non-copy argument, because the variants would each unpack the import, rather than re-using the single import.