### PR TITLE
Derive `Default` for `BinReadArgs` types when all args are optional

### DIFF
--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -195,6 +195,18 @@ fn empty_imports() {
 }
 
 #[test]
+fn all_default_imports() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(import { _default: u8 = 42 })]
+    struct Test {
+        a: u8,
+    }
+
+    let result = Test::read(&mut Cursor::new(b"\x01")).unwrap();
+    assert_eq!(result, Test { a: 1 });
+}
+
+#[test]
 fn if_alternate() {
     #[derive(BinRead, Debug)]
     #[br(import{ try_read: bool })]

--- a/binrw_derive/src/codegen/typed_builder.rs
+++ b/binrw_derive/src/codegen/typed_builder.rs
@@ -43,8 +43,13 @@ impl<'a> Builder<'a> {
         let possible_unwrap = self.fields.iter().map(BuilderField::possible_unwrap);
 
         let res_struct = if define_result {
+            let derives = if self.are_all_fields_optional() {
+                quote!(#[derive(Clone, Default)])
+            } else {
+                quote!(#[derive(Clone)])
+            };
             Some(quote!(
-                #[derive(Clone)]
+                #derives
                 #vis struct #name < #( #user_bounds ),* > {
                     #fields
                 }
@@ -235,6 +240,13 @@ impl<'a> Builder<'a> {
                     }
                 }
             )
+        })
+    }
+
+    fn are_all_fields_optional(&self) -> bool {
+        self.fields.iter().all(|field| match field.kind {
+            BuilderFieldKind::Optional { .. } => true,
+            _ => false,
         })
     }
 }


### PR DESCRIPTION
Currently, this does not compile:
```rust
#[derive(BinRead, Debug, PartialEq)]
#[br(import { _default: u8 = 42 })]
struct Test {
    a: u8,
}

let result = Test::read(&mut Cursor::new(b"\x01")).unwrap();
```
Because the generated `TestBinReadArgs` does not implement the `Default` trait, even though all imported arguments are optional and have default values.

This pull request fixes this issue by deriving `Default` for all generated `BinReadArgs` types whose arguments are all optional.