### PR TITLE
Use `Option<()>` instead of `bool` for keyword-only attributes.

### DIFF
--- a/binrw_derive/src/codegen/read_options/struct.rs
+++ b/binrw_derive/src/codegen/read_options/struct.rs
@@ -366,13 +366,13 @@ impl<'field> FieldGenerator<'field> {
 
     fn try_conversion(mut self) -> Self {
         if self.field.generated_value() {
-            if self.field.do_try {
+            if self.field.do_try.is_some() {
                 let value = self.out;
                 self.out = quote! { Some(#value) };
             }
         } else {
             let result = self.out;
-            self.out = if self.field.do_try {
+            self.out = if self.field.do_try.is_some() {
                 quote! { #result.ok() }
             } else {
                 quote! { #result? }
@@ -400,7 +400,7 @@ impl<'field> FieldGenerator<'field> {
     }
 
     fn wrap_restore_position(mut self) -> Self {
-        if self.field.restore_position {
+        if self.field.restore_position.is_some() {
             self.out = wrap_save_restore(self.out);
         }
 
@@ -505,7 +505,7 @@ fn generate_seek_before(field: &StructField) -> TokenStream {
 fn get_after_parse_handler(field: &StructField) -> Option<IdentStr> {
     if !field.can_call_after_parse() {
         None
-    } else if field.do_try {
+    } else if field.do_try.is_some() {
         Some(TRY_AFTER_PARSE)
     } else {
         Some(AFTER_PARSE)

--- a/binrw_derive/src/parser/attrs.rs
+++ b/binrw_derive/src/parser/attrs.rs
@@ -2,7 +2,7 @@ use super::{
     keywords as kw,
     meta_types::{
         IdentPatType, IdentTypeMaybeDefault, MetaEnclosedList, MetaExpr, MetaList, MetaLit,
-        MetaType, MetaValue,
+        MetaType, MetaValue, MetaVoid,
     },
 };
 use proc_macro2::TokenStream;
@@ -14,18 +14,18 @@ pub(crate) type Args = MetaEnclosedList<kw::args, Expr, TokenStream>;
 pub(crate) type ArgsRaw = MetaExpr<kw::args_raw>;
 pub(crate) type AssertLike<K> = MetaList<K, Expr>;
 pub(crate) type Assert = AssertLike<kw::assert>;
-pub(crate) type Big = kw::big;
+pub(crate) type Big = MetaVoid<kw::big>;
 pub(crate) type Calc = MetaExpr<kw::calc>;
 pub(crate) type Count = MetaExpr<kw::count>;
-pub(crate) type Default = kw::default;
-pub(crate) type DerefNow = kw::deref_now;
+pub(crate) type Default = MetaVoid<kw::default>;
+pub(crate) type DerefNow = MetaVoid<kw::deref_now>;
 pub(crate) type If = MetaList<Token![if], Expr>;
-pub(crate) type Ignore = kw::ignore;
+pub(crate) type Ignore = MetaVoid<kw::ignore>;
 pub(crate) type Import = MetaEnclosedList<kw::import, IdentPatType, IdentTypeMaybeDefault>;
 pub(crate) type ImportRaw = MetaValue<kw::import_raw, IdentPatType>;
 pub(crate) type IsBig = MetaExpr<kw::is_big>;
 pub(crate) type IsLittle = MetaExpr<kw::is_little>;
-pub(crate) type Little = kw::little;
+pub(crate) type Little = MetaVoid<kw::little>;
 pub(crate) type Magic = MetaLit<kw::magic>;
 pub(crate) type Map = MetaExpr<kw::map>;
 pub(crate) type Offset = MetaExpr<kw::offset>;
@@ -34,13 +34,13 @@ pub(crate) type PadAfter = MetaExpr<kw::pad_after>;
 pub(crate) type PadBefore = MetaExpr<kw::pad_before>;
 pub(crate) type PadSizeTo = MetaExpr<kw::pad_size_to>;
 pub(crate) type ParseWith = MetaExpr<kw::parse_with>;
-pub(crate) type PostProcessNow = kw::postprocess_now;
+pub(crate) type PostProcessNow = MetaVoid<kw::postprocess_now>;
 pub(crate) type PreAssert = AssertLike<kw::pre_assert>;
 pub(crate) type Repr = MetaType<kw::repr>;
-pub(crate) type RestorePosition = kw::restore_position;
-pub(crate) type ReturnAllErrors = kw::return_all_errors;
+pub(crate) type RestorePosition = MetaVoid<kw::restore_position>;
+pub(crate) type ReturnAllErrors = MetaVoid<kw::return_all_errors>;
 pub(crate) type ReturnUnexpectedError = kw::return_unexpected_error;
 pub(crate) type SeekBefore = MetaExpr<kw::seek_before>;
-pub(crate) type Temp = kw::temp;
-pub(crate) type Try = Token![try];
+pub(crate) type Temp = MetaVoid<kw::temp>;
+pub(crate) type Try = MetaVoid<Token![try]>;
 pub(crate) type TryMap = MetaExpr<kw::try_map>;

--- a/binrw_derive/src/parser/meta_types.rs
+++ b/binrw_derive/src/parser/meta_types.rs
@@ -37,6 +37,14 @@ pub(crate) struct MetaValue<Keyword, Value> {
     pub(crate) value: Value,
 }
 
+impl<Keyword: syn::token::Token + KeywordToken> KeywordToken for MetaVoid<Keyword> {
+    type Token = Keyword;
+
+    fn keyword_span(&self) -> proc_macro2::Span {
+        self.ident.keyword_span()
+    }
+}
+
 impl<Keyword: Parse, Value: Parse> Parse for MetaValue<Keyword, Value> {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let ident = input.parse()?;
@@ -71,6 +79,23 @@ impl<Keyword: syn::token::Token + KeywordToken, Value> KeywordToken for MetaValu
     fn keyword_span(&self) -> proc_macro2::Span {
         self.ident.keyword_span()
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MetaVoid<Keyword> {
+    pub(crate) ident: Keyword,
+}
+
+impl<Keyword: Parse> Parse for MetaVoid<Keyword> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        Ok(MetaVoid {
+            ident: input.parse()?,
+        })
+    }
+}
+
+impl<Keyword> From<MetaVoid<Keyword>> for () {
+    fn from(_: MetaVoid<Keyword>) -> Self {}
 }
 
 #[derive(Debug, Clone)]

--- a/binrw_derive/src/parser/mod.rs
+++ b/binrw_derive/src/parser/mod.rs
@@ -215,20 +215,6 @@ pub(crate) trait TrySet<T> {
     fn try_set(self, to: &mut T) -> syn::Result<()>;
 }
 
-impl<T: KeywordToken> TrySet<bool> for T {
-    fn try_set(self, to: &mut bool) -> syn::Result<()> {
-        if *to {
-            Err(syn::Error::new(
-                self.keyword_span(),
-                format!("conflicting {} keyword", self.dyn_display()),
-            ))
-        } else {
-            *to = true;
-            Ok(())
-        }
-    }
-}
-
 // TODO: This sucks
 pub(crate) enum TrySetError {
     Infallible,

--- a/binrw_derive/src/parser/top_level_attrs.rs
+++ b/binrw_derive/src/parser/top_level_attrs.rs
@@ -63,10 +63,16 @@ impl Input {
 
     pub(crate) fn is_temp_field(&self, variant_index: usize, index: usize) -> bool {
         match self {
-            Input::Struct(s) => s.fields.get(index).map_or(false, |field| field.temp),
+            Input::Struct(s) => s
+                .fields
+                .get(index)
+                .map_or(false, |field| field.temp.is_some()),
             Input::Enum(e) => e.variants.get(variant_index).map_or(false, |variant| {
                 if let EnumVariant::Variant { options, .. } = variant {
-                    options.fields.get(index).map_or(false, |field| field.temp)
+                    options
+                        .fields
+                        .get(index)
+                        .map_or(false, |field| field.temp.is_some())
                 } else {
                     false
                 }
@@ -128,9 +134,13 @@ impl Struct {
     }
 
     pub(crate) fn iter_permanent_idents(&self) -> impl Iterator<Item = &syn::Ident> + '_ {
-        self.fields
-            .iter()
-            .filter_map(|field| if field.temp { None } else { Some(&field.ident) })
+        self.fields.iter().filter_map(|field| {
+            if field.temp.is_some() {
+                None
+            } else {
+                Some(&field.ident)
+            }
+        })
     }
 }
 

--- a/binrw_derive/src/parser/top_level_attrs.rs
+++ b/binrw_derive/src/parser/top_level_attrs.rs
@@ -135,11 +135,7 @@ impl Struct {
 
     pub(crate) fn iter_permanent_idents(&self) -> impl Iterator<Item = &syn::Ident> + '_ {
         self.fields.iter().filter_map(|field| {
-            if field.temp.is_some() {
-                None
-            } else {
-                Some(&field.ident)
-            }
+            field.temp.is_none().then(|| &field.ident)
         })
     }
 }

--- a/binrw_derive/src/parser/top_level_attrs.rs
+++ b/binrw_derive/src/parser/top_level_attrs.rs
@@ -134,9 +134,9 @@ impl Struct {
     }
 
     pub(crate) fn iter_permanent_idents(&self) -> impl Iterator<Item = &syn::Ident> + '_ {
-        self.fields.iter().filter_map(|field| {
-            field.temp.is_none().then(|| &field.ident)
-        })
+        self.fields
+            .iter()
+            .filter_map(|field| field.temp.is_none().then(|| &field.ident))
     }
 }
 

--- a/binrw_derive/src/parser/types/spanned_value.rs
+++ b/binrw_derive/src/parser/types/spanned_value.rs
@@ -1,4 +1,4 @@
-use crate::parser::{KeywordToken, TrySet};
+use crate::parser::KeywordToken;
 use proc_macro2::Span;
 
 #[derive(Debug, Clone)]
@@ -10,15 +10,6 @@ pub(crate) struct SpannedValue<T> {
 impl<T> SpannedValue<T> {
     pub(crate) fn new(value: T, span: Span) -> Self {
         Self { value, span }
-    }
-}
-
-impl<T: Default> Default for SpannedValue<T> {
-    fn default() -> Self {
-        Self {
-            value: <_>::default(),
-            span: proc_macro2::Span::call_site(),
-        }
     }
 }
 
@@ -50,23 +41,6 @@ impl<T: Into<To> + KeywordToken, To> From<T> for SpannedValue<To> {
         Self {
             value: value.into(),
             span,
-        }
-    }
-}
-
-// TODO: This really should not be necessary but there are some really bad
-// generic trait conflicts when trying to just implement `From`.
-impl<T: KeywordToken> TrySet<SpannedValue<bool>> for T {
-    fn try_set(self, to: &mut SpannedValue<bool>) -> syn::Result<()> {
-        if to.value {
-            Err(syn::Error::new(
-                self.keyword_span(),
-                format!("conflicting {} keyword", self.dyn_display()),
-            ))
-        } else {
-            to.span = self.keyword_span();
-            to.value = true;
-            Ok(())
         }
     }
 }


### PR DESCRIPTION
Wrap keyword-only attribute types into a new `MetaVoid` type which
is convertible into `()`.

This makes the code more generic & consistent, no more specialized
implementation of `TrySet<bool>` & `TrySet<SpannedValue<bool>>`, no
more `Default` implementation for `SpannedValue<T>` which was only
used for `bool`. Having a default value for `SpannedValue` was a
bit inconsistent since the type is designed to wrap a span and in
the default case there is no span.