### PR TITLE
Display the actual attribute name for `AssertLike` attributes

### DIFF
--- a/binrw_derive/src/parser/types/assert.rs
+++ b/binrw_derive/src/parser/types/assert.rs
@@ -16,7 +16,7 @@ pub(crate) struct Assert {
     pub(crate) consequent: Option<Error>,
 }
 
-impl<K: Parse + Spanned> TryFrom<attrs::AssertLike<K>> for Assert {
+impl<K: Parse + Spanned + ToTokens> TryFrom<attrs::AssertLike<K>> for Assert {
     type Error = syn::Error;
 
     fn try_from(value: attrs::AssertLike<K>) -> Result<Self, Self::Error> {
@@ -27,7 +27,10 @@ impl<K: Parse + Spanned> TryFrom<attrs::AssertLike<K>> for Assert {
         } else {
             return Err(Self::Error::new(
                 value.ident.span(),
-                "`assert` requires a boolean expression as an argument",
+                format!(
+                    "`{}` requires a boolean expression as an argument",
+                    value.ident.into_token_stream()
+                ),
             ));
         };
 


### PR DESCRIPTION
When trying to use an `AssertLike` attribute without any argument like this:
```rust
enum Test {
    #[br(pre_assert()]
    Test(u8)
}
```
This error message is printed:
```
`assert` requires a boolean expression as an argument
```
This PR makes it print the actual keyword instead of the hard-coded `assert`.