### PR TITLE
Adds documentation for writing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,121 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+Beyond these notes, new contributors may find it helpful to store these commands in a local shell
+function or hotkey. They will help you on your journey.
+
+### Running doctests:
+
+```
+cargo test --doc
+```
+
+### Running all tests:
+
+```
+cargo test
+```
+
+### Linting with clippy:
+
+```
+cargo clippy --all-targets --no-default-features
+```
+
+### Pre-Commit:
+
+```
+cargo fmt -- --checK
+```
+If this does not already work in your development environment, you might need to run
+`rustup component add rustfmt` and try again.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change. 
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct).
 
 ## Pull Request Process
 
@@ -45,77 +45,3 @@ cargo fmt -- --checK
 If this does not already work in your development environment, you might need to run
 `rustup component add rustfmt` and try again.
 
-## Code of Conduct
-
-### Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
-
-### Our Standards
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-### Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-### Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-### Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/

--- a/binrw/src/attribute/write.rs
+++ b/binrw/src/attribute/write.rs
@@ -290,9 +290,6 @@
 //! assert_eq!(msg, Message { ty: 1, len: 4, data: Command::Variant1(0xFF) });
 //! ```
 //!
-//!
-//! todo
-//!
 //! # Byte Order
 //!
 //! todo

--- a/binrw/src/attribute/write.rs
+++ b/binrw/src/attribute/write.rs
@@ -233,9 +233,46 @@
 //!
 //! todo
 //!
-//! # Magic
 //!
-//! todo
+//! The `magic` directive matches [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming))
+//! in data:
+//!
+//! ```text
+//! #[bw(magic = $magic:literal)] or #[bw(magic($magic:literal))]
+//! ```
+//!
+//! The magic number can be a byte literal, byte string, char, float, or
+//! integer. When a magic number is matched, parsing begins with the first byte
+//! after the magic number in the data. When a magic number is not matched, an
+//! error is returned.
+//!
+//! ## Examples
+//!
+//! ```
+//! # use binrw::{prelude::*, io::Cursor};
+//! #[derive(BinWrite, Debug)]
+//! #[bw(magic = b"TEST")]
+//! struct Test {
+//!     val: u32
+//! }
+//!
+//! #[derive(BinWrite, Debug)]
+//! #[bw(magic = 1.2f32)]
+//! struct Version(u16);
+//!
+//! #[derive(BinWrite)]
+//! enum Command {
+//!     #[bw(magic = 0u8)] Nop,
+//!     #[bw(magic = 1u8)] Jump { loc: u32 },
+//!     #[bw(magic = 2u8)] Begin { var_count: u16, local_count: u16 }
+//! }
+//! ```
+//!
+//! ## Errors
+//!
+//! If the specified magic number does not match the data, a
+//! [`BadMagic`](crate::Error::BadMagic) error is returned and the writer’s
+//! position is reset to where it was before parsing started.
 //!
 //! # Map
 //!

--- a/binrw/src/attribute/write.rs
+++ b/binrw/src/attribute/write.rs
@@ -398,7 +398,7 @@
 //!
 //! ```
 //! # use binrw::{prelude::*, io::Cursor};
-//! # use std::convert::TryInto;
+//! # use core::convert::TryInto;
 //! #[derive(BinWrite)]
 //! struct MyType {
 //!     #[bw(try_map = |&x| -> BinResult<i8> { x.try_into().map_err(|_| todo!()) })]
@@ -442,8 +442,8 @@
 //!
 //! ## Errors
 //!
-//! If the `try_map` function returns a [`binrw::io::Error`](crate::io::Error)
-//! or [`std::io::Error`], an [`Io`](crate::Error::Io) error is returned. For
+//! If the `try_map` function returns a [`binrw::io::Error`](crate::io::Error) or
+//! a [`std::io::Error`](crate::io::Error), an [`Io`](crate::Error::Io) error is returned. For
 //! any other error type, a [`Custom`](crate::Error::Custom) error is returned.
 //!
 //! In all cases, the writer’s position is reset to where it was before parsing

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -138,6 +138,19 @@ where
     func
 }
 
+pub fn write_fn_try_map_output_type_hint<Input, Output, MapFn, Writer, WriteFn, Args>(
+    _: &MapFn,
+    func: WriteFn,
+) -> WriteFn
+where
+    MapFn: FnOnce(Input) -> BinResult<Output>,
+    Args: Clone,
+    Writer: Write + Seek,
+    WriteFn: Fn(&Output, &mut Writer, &WriteOptions, Args) -> BinResult<()>,
+{
+    func
+}
+
 pub fn write_zeroes<W: Write>(writer: &mut W, count: u64) -> BinResult<()> {
     const BUF_SIZE: u64 = 0x20;
     const ZEROES: [u8; BUF_SIZE as usize] = [0u8; BUF_SIZE as usize];

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -39,3 +39,15 @@ fn map_field_code_coverage() {
         y: String,
     }
 }
+
+#[test]
+fn try_map() {
+    use binrw::prelude::*;
+    use std::convert::TryInto;
+
+    #[derive(BinWrite)]
+    struct MyType {
+        #[bw(try_map = |x| -> BinResult<i8> { x.try_into().map_err(|_| todo!()) })]
+        value: u8,
+    }
+}

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -47,7 +47,7 @@ fn try_map() {
 
     #[derive(BinWrite)]
     struct MyType {
-        #[bw(try_map = |x| -> BinResult<i8> { x.try_into().map_err(|_| todo!()) })]
+        #[bw(try_map = |&x| -> BinResult<i8> { x.try_into().map_err(|_| todo!()) })]
         value: u8,
     }
 }

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -71,6 +71,7 @@ ident_str! {
     pub(crate) WRITE_TRY_MAP_ARGS_TYPE_HINT = from_crate!(__private::write_try_map_args_type_hint);
     pub(crate) WRITE_MAP_INPUT_TYPE_HINT = from_crate!(__private::write_map_fn_input_type_hint);
     pub(crate) WRITE_FN_MAP_OUTPUT_TYPE_HINT = from_crate!(__private::write_fn_map_output_type_hint);
+    pub(crate) WRITE_FN_TRY_MAP_OUTPUT_TYPE_HINT = from_crate!(__private::write_fn_try_map_output_type_hint);
     pub(crate) WRITE_ZEROES = from_crate!(__private::write_zeroes);
     pub(crate) SATISFIED_OR_OPTIONAL = from_crate!(SatisfiedOrOptional);
     pub(crate) SATISFIED = from_crate!(Satisfied);

--- a/binrw_derive/src/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/codegen/write_options/struct_field.rs
@@ -82,7 +82,11 @@ impl<'a> StructFieldGenerator<'a> {
 
         let write_fn = if self.field.map.is_some() {
             let map_fn = self.map_fn_ident();
-            quote! { #WRITE_FN_MAP_OUTPUT_TYPE_HINT(&#map_fn, #write_fn) }
+            if self.field.map.is_try() {
+                quote! { #WRITE_FN_TRY_MAP_OUTPUT_TYPE_HINT(&#map_fn, #write_fn) }
+            } else {
+                quote! { #WRITE_FN_MAP_OUTPUT_TYPE_HINT(&#map_fn, #write_fn) }
+            }
         } else {
             quote! { #WRITE_FN_TYPE_HINT(#write_fn) }
         };


### PR DESCRIPTION
If accepted, this PR partially closes issue #54 . I'm looking for some feedback on what's present, but also some direction on [Padding and Alignment](https://github.com/dmgolembiowski/binrw/blob/master/binrw/src/attribute/write.rs#L34-L37), [Byte Order](https://github.com/dmgolembiowski/binrw/blob/master/binrw/src/attribute/write.rs#L293-L296), [Ignore](https://github.com/dmgolembiowski/binrw/blob/master/binrw/src/attribute/write.rs#L352-L356), [Repr](https://github.com/dmgolembiowski/binrw/blob/master/binrw/src/attribute/write.rs#L494-L497), and most of all [Custom Writers](https://github.com/dmgolembiowski/binrw/blob/master/binrw/src/attribute/write.rs#L528-L530).

Update:
Hm... seeing a lot of 
```autohotkey
method cannot be called on `std::io::Cursor<&[u8; 8]>` due to unsatisfied trait bounds
```
on every `write_be` call. Is it better to update the trait bound or the method to be called?