### PR TITLE
Implement helper functions with custom parsers

### DIFF
--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -73,6 +73,23 @@ where
 }
 
 /// Do the same as [until](binrw::helpers::until) with a custom parsing function for the inner type.
+///
+/// # Examples
+///
+/// This example shows how to read lists of two elements until a condition is met using [until_with](binrw::helpers::until_with) coupled with [count](binrw::helpers::count).
+/// ```
+/// # use binrw::{BinRead, helpers::{until, until_with, count}, io::Cursor, BinReaderExt};
+/// # use std::collections::VecDeque;
+/// #[derive(BinRead)]
+/// struct NullTerminated {
+///     #[br(parse_with = until_with(|bytes| bytes == &[0, 0], count(2)))]
+///     data: VecDeque<VecDeque<u8>>,
+/// }
+///
+/// # let mut x = Cursor::new(b"\x01\x02\x03\x04\0\0");
+/// # let x: NullTerminated = x.read_be().unwrap();
+/// # assert_eq!(x.data, &[[1, 2], [3, 4], [0, 0]]);
+/// ```
 pub fn until_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
     cond: CondFn,
     read: ReadFn,
@@ -136,6 +153,23 @@ where
 }
 
 /// Do the same as [until_exclusive](binrw::helpers::until_exclusive) with a custom parsing function for the inner type.
+///
+/// # Examples
+///
+/// This example shows how to read lists of two elements until a condition is met using [until_exclusive_with](binrw::helpers::until_exclusive_with) coupled with [count](binrw::helpers::count).
+/// ```
+/// # use binrw::{BinRead, helpers::{until_exclusive, until_exclusive_with, count}, io::Cursor, BinReaderExt};
+/// # use std::collections::VecDeque;
+/// #[derive(BinRead)]
+/// struct NullTerminated {
+///     #[br(parse_with = until_exclusive_with(|bytes| bytes == &[0, 0], count(2)))]
+///     data: VecDeque<VecDeque<u8>>,
+/// }
+///
+/// # let mut x = Cursor::new(b"\x01\x02\x03\x04\0\0");
+/// # let x: NullTerminated = x.read_be().unwrap();
+/// # assert_eq!(x.data, &[[1, 2], [3, 4]]);
+/// ```
 pub fn until_exclusive_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
     cond: CondFn,
     read: ReadFn,
@@ -199,6 +233,23 @@ where
 }
 
 /// Do the same as [until_eof](binrw::helpers::until_eof) with a custom parsing function for the inner type.
+///
+/// # Examples
+///
+/// This example shows how to read lists of two elements until the end of file using [until_eof_with](binrw::helpers::until_eof_with) coupled with [count](binrw::helpers::count).
+/// ```
+/// # use binrw::{BinRead, helpers::{until_eof, until_eof_with, count}, io::Cursor, BinReaderExt};
+/// # use std::collections::VecDeque;
+/// #[derive(BinRead)]
+/// struct EntireFile {
+///     #[br(parse_with = until_eof_with(count(2)))]
+///     data: VecDeque<VecDeque<u8>>,
+/// }
+///
+/// # let mut x = Cursor::new(b"\x01\x02\x03\x04");
+/// # let x: EntireFile = x.read_be().unwrap();
+/// # assert_eq!(x.data, &[[1, 2], [3, 4]]);
+/// ```
 pub fn until_eof_with<Reader, T, Arg, ReadFn, Ret>(
     read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
@@ -284,6 +335,7 @@ where
 ///
 /// # Examples
 ///
+/// This example shows how to read `len` lists of two elements using [count_with](binrw::helpers::count_with) coupled with [count](binrw::helpers::count).
 /// ```
 /// # use binrw::{BinRead, helpers::count, helpers::count_with, io::Cursor, BinReaderExt};
 /// # use std::collections::VecDeque;

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -39,8 +39,8 @@ pub fn read_bytes<R: Read + Seek>(
 }
 
 pub fn until_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
-    read: ReadFn,
     cond: CondFn,
+    read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
     Reader: Read + Seek,
@@ -97,7 +97,7 @@ where
         value.after_parse(reader, ro, args)?;
         Ok(value)
     };
-    until_with(read, cond)
+    until_with(cond, read)
 }
 
 /// Read items until a condition is met. The last item will *not* be included.
@@ -131,12 +131,12 @@ where
         value.after_parse(reader, ro, args)?;
         Ok(value)
     };
-    until_exclusive_with(read, cond)
+    until_exclusive_with(cond, read)
 }
 
 pub fn until_exclusive_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
-    read: ReadFn,
     cond: CondFn,
+    read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
     Reader: Read + Seek,
@@ -272,14 +272,14 @@ where
                 value.after_parse(reader, ro, args)?;
                 Ok(value)
             };
-            count_with(read, n)(reader, ro, args)
+            count_with(n, read)(reader, ro, args)
         }
     }
 }
 
 pub fn count_with<R, T, Arg, ReadFn, Ret>(
-    read: ReadFn,
     n: usize,
+    read: ReadFn,
 ) -> impl Fn(&mut R, &ReadOptions, Arg) -> BinResult<Ret>
 where
     T: BinRead<Args = Arg>,


### PR DESCRIPTION
One might want to pass a custom parser for the inner type when using `until`-like parsers or `count`.
- [x] `until_with`
- [x] `until_exclusive_with`
- [x] `until_eof_with`
- [x] `count_with`
- [ ] tests
- [x] documentation