### PR TITLE
Add a `multi` helper for reading a slice of args

### DIFF
--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -367,8 +367,8 @@ where
     }
 }
 
-/// A helper that takes a slice of arguments and reads items for each argument,
-/// and collecting that as a single collection.
+/// A helper that takes a slice of arguments and reads an item for each argument, and collects that
+/// as a single collection.
 ///
 /// # Examples
 ///

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -69,7 +69,7 @@ where
     }
 }
 
-pub fn parse_function_args_type_hint<R, Res, Args, F>(_: F, a: Args) -> Args
+pub fn parse_function_args_type_hint<R, Res, Args, F>(_: &F, a: Args) -> Args
 where
     R: crate::io::Read + Seek,
     F: FnOnce(&mut R, &crate::ReadOptions, Args) -> crate::BinResult<Res>,
@@ -77,7 +77,7 @@ where
     a
 }
 
-pub fn write_function_args_type_hint<T, W, Args, F>(_: F, a: Args) -> Args
+pub fn write_function_args_type_hint<T, W, Args, F>(_: &F, a: Args) -> Args
 where
     W: Write + Seek,
     F: FnOnce(&T, &mut W, &crate::WriteOptions, Args) -> crate::BinResult<()>,

--- a/binrw_derive/src/codegen/read_options/struct.rs
+++ b/binrw_derive/src/codegen/read_options/struct.rs
@@ -373,7 +373,7 @@ impl<'field> FieldGenerator<'field> {
 
             if let ReadMode::ParseWith(_) = &self.field.read_mode {
                 quote! {
-                    let #args_var = #ARGS_TYPE_HINT::<R, #ty, _, _>(#READ_FUNCTION, #args);
+                    let #args_var = #ARGS_TYPE_HINT::<R, #ty, _, _>(&#READ_FUNCTION, #args);
                 }
             } else {
                 match &self.field.map {

--- a/binrw_derive/src/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/codegen/write_options/struct_field.rs
@@ -348,7 +348,7 @@ impl<'a> StructFieldGenerator<'a> {
                 let ty = &self.field.ty;
                 quote! {
                     let #args = #WRITE_WITH_ARGS_TYPE_HINT::<#ty, W, _, _>(
-                        #WRITE_FUNCTION, #args_val
+                        &#WRITE_FUNCTION, #args_val
                     );
                     #out
                 }


### PR DESCRIPTION
This works similarly to `count`, but takes `&[Args]` instead of using a length + cloning the same args.

Name might not be the best -- I avoided using the more obvious `map` as unlike `count` this is _not_ analogous to the `map` attribute.