### PR TITLE
Fix until_eof

### DIFF
--- a/binrw/src/error/mod.rs
+++ b/binrw/src/error/mod.rs
@@ -183,6 +183,12 @@ impl Error {
         }
     }
 
+    /// Check if the [root cause][`Self::root_cause`] of this error is an [`Error::Io`] and an
+    /// [`io::ErrorKind::UnexpectedEof`].
+    pub fn is_eof(&self) -> bool {
+        matches!(self.root_cause(), Error::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof)
+    }
+
     /// Returns a reference to the boxed error object if this `Error` is a
     /// custom error of type `T`, or `None` if it isn’t.
     pub fn custom_err<T: CustomError + 'static>(&self) -> Option<&T> {

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Helper functions for reading data.
 
 use crate::{
-    io::{self, ErrorKind::UnexpectedEof, Read, Seek},
+    io::{self, Read, Seek},
     BinRead, BinResult, Error, ReadOptions, VecArgs,
 };
 use core::convert::TryInto;
@@ -266,7 +266,7 @@ where
                 !last_error
                     && match result {
                         Ok(_) => true,
-                        Err(ref e) if is_eof(e) => false,
+                        Err(e) if e.is_eof() => false,
                         Err(_) => {
                             last_error = true;
                             true //keep the first error we get
@@ -274,13 +274,6 @@ where
                     }
             })
             .collect()
-    }
-}
-
-fn is_eof(e: &crate::error::Error) -> bool {
-    match e.root_cause() {
-        crate::error::Error::Io(err) if err.kind() == UnexpectedEof => true,
-        _ => false,
     }
 }
 

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -266,7 +266,7 @@ where
                 !last_error
                     && match result {
                         Ok(_) => true,
-                        Err(crate::Error::Io(err)) if err.kind() == UnexpectedEof => false,
+                        Err(ref e) if is_eof(e) => false,
                         Err(_) => {
                             last_error = true;
                             true //keep the first error we get
@@ -274,6 +274,13 @@ where
                     }
             })
             .collect()
+    }
+}
+
+fn is_eof(e: &crate::error::Error) -> bool {
+    match e.root_cause() {
+        crate::error::Error::Io(err) if err.kind() == UnexpectedEof => true,
+        _ => false,
     }
 }
 


### PR DESCRIPTION
Without calling root_cause, backtraces would not be correctly determined as an EOF.