### PR TITLE
Fix import arg type name collision with both read and write

### DIFF
--- a/binrw_derive/src/codegen/imports.rs
+++ b/binrw_derive/src/codegen/imports.rs
@@ -11,7 +11,7 @@ impl Imports {
     pub fn destructure(&self, type_name: Option<&Ident>) -> Option<TokenStream> {
         match self {
             Imports::None => None,
-            Imports::List(idents, _, _) => {
+            Imports::List(idents, _) => {
                 if idents.is_empty() {
                     None
                 } else {
@@ -43,7 +43,7 @@ impl Imports {
     ) -> (TokenStream, Option<TokenStream>) {
         match self {
             Imports::None => (quote! { () }, None),
-            Imports::List(_, types, _) => {
+            Imports::List(_, types) => {
                 let types = types.iter();
                 (
                     quote! {

--- a/binrw_derive/src/parser/read/attrs.rs
+++ b/binrw_derive/src/parser/read/attrs.rs
@@ -4,9 +4,26 @@ use super::super::{
         IdentPatType, IdentTypeMaybeDefault, MetaEnclosedList, MetaExpr, MetaList, MetaLit,
         MetaType, MetaValue, MetaVoid,
     },
+    KeywordToken,
 };
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use syn::{Expr, Token};
+
+pub struct ReadOnlyAttr<T>(pub T);
+
+impl<T: KeywordToken> KeywordToken for crate::parser::read::attrs::ReadOnlyAttr<T> {
+    type Token = T::Token;
+
+    fn keyword_span(&self) -> Span {
+        T::keyword_span(&self.0)
+    }
+}
+
+impl<T: syn::parse::Parse> syn::parse::Parse for ReadOnlyAttr<T> {
+    fn parse(buf: &syn::parse::ParseBuffer<'_>) -> std::result::Result<Self, syn::Error> {
+        T::parse(buf).map(|x| ReadOnlyAttr(x))
+    }
+}
 
 pub(crate) type AlignAfter = MetaExpr<kw::align_after>;
 pub(crate) type AlignBefore = MetaExpr<kw::align_before>;
@@ -22,7 +39,8 @@ pub(crate) type DerefNow = MetaVoid<kw::deref_now>;
 pub(crate) type ErrContext = MetaList<kw::err_context, Expr>;
 pub(crate) type If = MetaList<Token![if], Expr>;
 pub(crate) type Ignore = MetaVoid<kw::ignore>;
-pub(crate) type Import = MetaEnclosedList<kw::import, IdentPatType, IdentTypeMaybeDefault>;
+pub(crate) type Import =
+    ReadOnlyAttr<MetaEnclosedList<kw::import, IdentPatType, IdentTypeMaybeDefault>>;
 pub(crate) type ImportRaw = MetaValue<kw::import_raw, IdentPatType>;
 pub(crate) type IsBig = MetaExpr<kw::is_big>;
 pub(crate) type IsLittle = MetaExpr<kw::is_little>;

--- a/binrw_derive/src/parser/read/attrs.rs
+++ b/binrw_derive/src/parser/read/attrs.rs
@@ -7,11 +7,14 @@ use super::super::{
     KeywordToken,
 };
 use proc_macro2::{Span, TokenStream};
-use syn::{Expr, Token};
+use syn::{
+    parse::{Parse, ParseBuffer},
+    Expr, Token,
+};
 
 pub struct ReadOnlyAttr<T>(pub T);
 
-impl<T: KeywordToken> KeywordToken for crate::parser::read::attrs::ReadOnlyAttr<T> {
+impl<T: KeywordToken> KeywordToken for ReadOnlyAttr<T> {
     type Token = T::Token;
 
     fn keyword_span(&self) -> Span {
@@ -19,8 +22,8 @@ impl<T: KeywordToken> KeywordToken for crate::parser::read::attrs::ReadOnlyAttr<
     }
 }
 
-impl<T: syn::parse::Parse> syn::parse::Parse for ReadOnlyAttr<T> {
-    fn parse(buf: &syn::parse::ParseBuffer<'_>) -> std::result::Result<Self, syn::Error> {
+impl<T: Parse> Parse for ReadOnlyAttr<T> {
+    fn parse(buf: &ParseBuffer<'_>) -> Result<Self, syn::Error> {
         T::parse(buf).map(|x| ReadOnlyAttr(x))
     }
 }

--- a/binrw_derive/src/parser/types/imports.rs
+++ b/binrw_derive/src/parser/types/imports.rs
@@ -9,7 +9,7 @@ use syn::{Ident, Type};
 pub(crate) enum Imports {
     None,
     Raw(Ident, Box<Type>),
-    List(Vec<Ident>, Vec<Type>, bool),
+    List(Vec<Ident>, Vec<Type>),
     Named(Vec<IdentTypeMaybeDefault>, bool),
 }
 
@@ -33,7 +33,7 @@ fn imports_from_attr(
                     .cloned()
                     .map(|field| (field.ident, field.ty))
                     .unzip();
-                Imports::List(idents, tys, is_write)
+                Imports::List(idents, tys)
             }
         }
         Enclosure::Brace { fields, .. } => {

--- a/binrw_derive/src/parser/types/imports.rs
+++ b/binrw_derive/src/parser/types/imports.rs
@@ -1,7 +1,6 @@
 use crate::parser::{
-    meta_types::{Enclosure, IdentTypeMaybeDefault},
-    read::attrs,
-    KeywordToken, TrySet,
+    meta_types::{Enclosure, IdentPatType, IdentTypeMaybeDefault},
+    read, write, KeywordToken, TrySet,
 };
 
 use syn::{Ident, Type};
@@ -10,8 +9,8 @@ use syn::{Ident, Type};
 pub(crate) enum Imports {
     None,
     Raw(Ident, Box<Type>),
-    List(Vec<Ident>, Vec<Type>),
-    Named(Vec<IdentTypeMaybeDefault>),
+    List(Vec<Ident>, Vec<Type>, bool),
+    Named(Vec<IdentTypeMaybeDefault>, bool),
 }
 
 impl Default for Imports {
@@ -20,34 +19,47 @@ impl Default for Imports {
     }
 }
 
-impl From<attrs::Import> for Imports {
-    fn from(value: attrs::Import) -> Self {
-        match &value.list {
-            Enclosure::Paren { fields, .. } => {
-                if fields.is_empty() {
-                    Self::None
-                } else {
-                    let (idents, tys) = fields
-                        .iter()
-                        .cloned()
-                        .map(|field| (field.ident, field.ty))
-                        .unzip();
-                    Self::List(idents, tys)
-                }
+fn imports_from_attr(
+    list: &Enclosure<IdentPatType, IdentTypeMaybeDefault>,
+    is_write: bool,
+) -> Imports {
+    match list {
+        Enclosure::Paren { fields, .. } => {
+            if fields.is_empty() {
+                Imports::None
+            } else {
+                let (idents, tys) = fields
+                    .iter()
+                    .cloned()
+                    .map(|field| (field.ident, field.ty))
+                    .unzip();
+                Imports::List(idents, tys, is_write)
             }
-            Enclosure::Brace { fields, .. } => {
-                if fields.is_empty() {
-                    Self::None
-                } else {
-                    Self::Named(fields.iter().cloned().collect())
-                }
+        }
+        Enclosure::Brace { fields, .. } => {
+            if fields.is_empty() {
+                Imports::None
+            } else {
+                Imports::Named(fields.iter().cloned().collect(), is_write)
             }
         }
     }
 }
 
-impl From<attrs::ImportRaw> for Imports {
-    fn from(value: attrs::ImportRaw) -> Self {
+impl From<read::attrs::Import> for Imports {
+    fn from(value: read::attrs::Import) -> Self {
+        imports_from_attr(&value.0.list, false)
+    }
+}
+
+impl From<write::attrs::Import> for Imports {
+    fn from(value: write::attrs::Import) -> Self {
+        imports_from_attr(&value.0.list, true)
+    }
+}
+
+impl From<read::attrs::ImportRaw> for Imports {
+    fn from(value: read::attrs::ImportRaw) -> Self {
         Imports::Raw(value.value.ident, value.value.ty.into())
     }
 }

--- a/binrw_derive/src/parser/write/attrs.rs
+++ b/binrw_derive/src/parser/write/attrs.rs
@@ -4,9 +4,26 @@ use super::super::{
         IdentPatType, IdentTypeMaybeDefault, MetaEnclosedList, MetaExpr, MetaList, MetaLit,
         MetaType, MetaValue, MetaVoid,
     },
+    KeywordToken,
 };
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use syn::Expr;
+
+pub struct WriteOnlyAttr<T>(pub T);
+
+impl<T: KeywordToken> KeywordToken for crate::parser::write::attrs::WriteOnlyAttr<T> {
+    type Token = T::Token;
+
+    fn keyword_span(&self) -> Span {
+        T::keyword_span(&self.0)
+    }
+}
+
+impl<T: syn::parse::Parse> syn::parse::Parse for WriteOnlyAttr<T> {
+    fn parse(buf: &syn::parse::ParseBuffer<'_>) -> std::result::Result<Self, syn::Error> {
+        T::parse(buf).map(|x| WriteOnlyAttr(x))
+    }
+}
 
 pub(crate) type AlignAfter = MetaExpr<kw::align_after>;
 pub(crate) type AlignBefore = MetaExpr<kw::align_before>;
@@ -18,7 +35,8 @@ pub(crate) type Big = MetaVoid<kw::big>;
 pub(crate) type Calc = MetaExpr<kw::calc>;
 pub(crate) type Count = MetaExpr<kw::count>;
 pub(crate) type Ignore = MetaVoid<kw::ignore>;
-pub(crate) type Import = MetaEnclosedList<kw::import, IdentPatType, IdentTypeMaybeDefault>;
+pub(crate) type Import =
+    WriteOnlyAttr<MetaEnclosedList<kw::import, IdentPatType, IdentTypeMaybeDefault>>;
 pub(crate) type ImportRaw = MetaValue<kw::import_raw, IdentPatType>;
 pub(crate) type IsBig = MetaExpr<kw::is_big>;
 pub(crate) type IsLittle = MetaExpr<kw::is_little>;

--- a/binrw_derive/src/parser/write/attrs.rs
+++ b/binrw_derive/src/parser/write/attrs.rs
@@ -7,11 +7,14 @@ use super::super::{
     KeywordToken,
 };
 use proc_macro2::{Span, TokenStream};
-use syn::Expr;
+use syn::{
+    parse::{Parse, ParseBuffer},
+    Expr,
+};
 
 pub struct WriteOnlyAttr<T>(pub T);
 
-impl<T: KeywordToken> KeywordToken for crate::parser::write::attrs::WriteOnlyAttr<T> {
+impl<T: KeywordToken> KeywordToken for WriteOnlyAttr<T> {
     type Token = T::Token;
 
     fn keyword_span(&self) -> Span {
@@ -19,8 +22,8 @@ impl<T: KeywordToken> KeywordToken for crate::parser::write::attrs::WriteOnlyAtt
     }
 }
 
-impl<T: syn::parse::Parse> syn::parse::Parse for WriteOnlyAttr<T> {
-    fn parse(buf: &syn::parse::ParseBuffer<'_>) -> std::result::Result<Self, syn::Error> {
+impl<T: Parse> Parse for WriteOnlyAttr<T> {
+    fn parse(buf: &ParseBuffer<'_>) -> Result<Self, syn::Error> {
         T::parse(buf).map(|x| WriteOnlyAttr(x))
     }
 }


### PR DESCRIPTION
This is a pretty ugly fix for the issue of args and argbuilders having the same suffix in both read and write implementations causing a naming collision.