### PR TITLE
Validate that binwrite temp applies to binread too

### DIFF
--- a/binrw/tests/derive/binwrite_temp.rs
+++ b/binrw/tests/derive/binwrite_temp.rs
@@ -6,7 +6,6 @@ fn binwrite_temp_applies() {
     #[derive(Debug, PartialEq)]
     #[br(big)]
     struct Test {
-        #[br(temp)]
         #[bw(calc = vec.len() as u32)]
         len: u32,
 


### PR DESCRIPTION
This was already true in #70, but for some reason the test wasn't adjusted to indicate that.