### PR TITLE
Document the args! macro more thoroughly.

### DIFF
--- a/binrw/src/builder_types.rs
+++ b/binrw/src/builder_types.rs
@@ -30,7 +30,7 @@ pub fn builder_helper<T: BinrwNamedArgs>(_: PhantomData<T>) -> T::Builder {
 
 /// A macro for creating a binrw argument type
 ///
-/// This macro avoids taking an explicit type by inferring the return type.
+/// This macro avoids taking an explicit type by inferring the type it should create.
 /// In general, the result should have an explicit type *immediately*.
 /// i.e. being passed to a function or let binding with specific type.
 #[macro_export]
@@ -39,8 +39,8 @@ macro_rules! args {
     (@ifn {} $name:ident) => { $name };
     ($($name:ident $(: $value:expr)?),*) => {
         {
-            // I'll use Ret to mean the return type
-            // token representing the return type. we request that the compiler infer it.
+            // I'll use Ret to represent the type of the block
+            // token representing the type of the block. we request that the compiler infer it.
             let __args_ty = ::core::marker::PhantomData::<_>;
             if false {
                 // this statement will never be run, but will be used for type resolution.
@@ -50,11 +50,11 @@ macro_rules! args {
                 $crate::passthrough_helper(__args_ty)
             } else {
                 // we now pass the PhantomData<Ret> to a helper of PhantomData<T> -> T::Builder
-                // to obtain a builder for the return type.
+                // to obtain a builder for the type of the block.
                 let __builder = $crate::builder_helper(__args_ty);
-                
+
                 $(let __builder = __builder.$name($crate::args!(@ifn { $($value)? } $name));)*
-                
+
                 // since the builder returns the type that we used to obtain the builder,
                 // the type unifies across the if expression
                 __builder.finalize()


### PR DESCRIPTION
This macro is a confusing type-system hack, and as pointed out on discord, it kinda needs a "what is this/why is this" comment.