### PR TITLE
Strip 'r#' prefix of raw identifiers when generating binrw identifiers

### DIFF
--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -409,6 +409,16 @@ fn offset_after() {
 }
 
 #[test]
+fn raw_ident() {
+    #[derive(BinRead)]
+    struct Test {
+        r#type: u32,
+    }
+
+    Test::read(&mut Cursor::new(vec![0x00, 0x00, 0x00, 0x00])).unwrap();
+}
+
+#[test]
 fn rewind_on_assert() {
     #[derive(BinRead, Debug)]
     #[br(assert(b == 1))]

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -91,7 +91,9 @@ ident_str! {
 }
 
 pub(crate) fn make_ident(ident: &Ident, kind: &str) -> Ident {
-    format_ident!("__binrw_generated_{}_{}", kind, ident.to_string())
+    let ident_string = ident.to_string();
+    let ident_string = ident_string.strip_prefix("r#").unwrap_or(&ident_string);
+    format_ident!("__binrw_generated_{}_{}", kind, ident_string)
 }
 
 /// A string wrapper that converts the str to a $path `TokenStream`, allowing


### PR DESCRIPTION
Since one cannot use both `r#name` and `name` idents in a same context, there should not be any collision.
Fix issue #100.