### PR TITLE
Implement `repr` attribute for conversion.

### DIFF
--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -110,9 +110,13 @@ where
     args
 }
 
-pub fn write_try_map_args_type_hint<Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
+pub fn write_try_map_args_type_hint<Input, Output, Error, MapFn, Args>(
+    _: &MapFn,
+    args: Args,
+) -> Args
 where
-    MapFn: FnOnce(Input) -> BinResult<Output>,
+    Error: CustomError,
+    MapFn: FnOnce(Input) -> Result<Output, Error>,
     Output: crate::BinWrite<Args = Args>,
 {
     args
@@ -138,12 +142,13 @@ where
     func
 }
 
-pub fn write_fn_try_map_output_type_hint<Input, Output, MapFn, Writer, WriteFn, Args>(
+pub fn write_fn_try_map_output_type_hint<Input, Output, Error, MapFn, Writer, WriteFn, Args>(
     _: &MapFn,
     func: WriteFn,
 ) -> WriteFn
 where
-    MapFn: FnOnce(Input) -> BinResult<Output>,
+    Error: CustomError,
+    MapFn: FnOnce(Input) -> Result<Output, Error>,
     Args: Clone,
     Writer: Write + Seek,
     WriteFn: Fn(&Output, &mut Writer, &WriteOptions, Args) -> BinResult<()>,

--- a/binrw/tests/derive/struct_map.rs
+++ b/binrw/tests/derive/struct_map.rs
@@ -35,6 +35,30 @@ fn map_expr() {
 }
 
 #[test]
+fn map_repr() {
+    #[derive(BinRead, Debug)]
+    #[br(big)]
+    struct Test {
+        #[br(repr = u8)]
+        a: SubTest,
+    }
+
+    #[derive(Debug)]
+    struct SubTest {
+        a: u8,
+    }
+
+    impl From<u8> for SubTest {
+        fn from(a: u8) -> Self {
+            Self { a }
+        }
+    }
+
+    let result = Test::read(&mut Cursor::new("\x01")).unwrap();
+    assert_eq!(result.a.a, 1);
+}
+
+#[test]
 fn map_struct() {
     #[derive(BinRead, Debug)]
     #[br(map = Self::from_bytes)]

--- a/binrw/tests/derive/struct_map.rs
+++ b/binrw/tests/derive/struct_map.rs
@@ -35,7 +35,63 @@ fn map_expr() {
 }
 
 #[test]
-fn map_repr() {
+fn map_repr_enum() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(repr = u8)]
+    enum Test {
+        SubTest(u8),
+    }
+
+    impl From<u8> for Test {
+        fn from(u: u8) -> Self {
+            Self::SubTest(u)
+        }
+    }
+
+    let result = Test::read(&mut Cursor::new("\x01")).unwrap();
+    assert_eq!(result, Test::SubTest(1));
+}
+
+#[test]
+fn map_repr_enum_variant() {
+    #[derive(BinRead, Debug, PartialEq)]
+    enum Test {
+        SubTest(#[br(repr = u8)] SubTest),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct SubTest(u8);
+
+    impl From<u8> for SubTest {
+        fn from(u: u8) -> Self {
+            Self(u)
+        }
+    }
+
+    let result = Test::read(&mut Cursor::new("\x01")).unwrap();
+    assert_eq!(result, Test::SubTest(SubTest(1)));
+}
+
+#[test]
+fn map_repr_struct() {
+    #[derive(BinRead, Debug)]
+    #[br(repr = u8)]
+    struct Test {
+        a: u8,
+    }
+
+    impl From<u8> for Test {
+        fn from(a: u8) -> Self {
+            Self { a }
+        }
+    }
+
+    let result = Test::read(&mut Cursor::new("\x01")).unwrap();
+    assert_eq!(result.a, 1);
+}
+
+#[test]
+fn map_repr_struct_field() {
     #[derive(BinRead, Debug)]
     #[br(big)]
     struct Test {

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -41,6 +41,27 @@ fn map_field_code_coverage() {
 }
 
 #[test]
+fn map_repr() {
+    #[derive(BinWrite, Debug)]
+    #[bw(big)]
+    struct Test {
+        #[bw(repr = u8)]
+        a: SubTest,
+    }
+
+    #[derive(Debug)]
+    struct SubTest {
+        a: u8,
+    }
+
+    impl From<&SubTest> for u8 {
+        fn from(s: &SubTest) -> Self {
+            s.a
+        }
+    }
+}
+
+#[test]
 fn try_map() {
     use binrw::prelude::*;
     use std::convert::TryInto;

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -41,7 +41,56 @@ fn map_field_code_coverage() {
 }
 
 #[test]
-fn map_repr() {
+fn map_repr_enum() {
+    #[derive(BinWrite, Debug)]
+    #[bw(repr = u8)]
+    enum Test {
+        SubTest(u8),
+    }
+
+    impl From<&Test> for u8 {
+        fn from(t: &Test) -> Self {
+            match t {
+                Test::SubTest(u) => *u,
+            }
+        }
+    }
+}
+
+#[test]
+fn map_repr_enum_variant() {
+    #[derive(BinWrite, Debug)]
+    enum Test {
+        SubTest(#[bw(repr = u8)] SubTest),
+    }
+
+    #[derive(Debug)]
+    struct SubTest(u8);
+
+    impl From<&SubTest> for u8 {
+        fn from(s: &SubTest) -> Self {
+            s.0
+        }
+    }
+}
+
+#[test]
+fn map_repr_struct() {
+    #[derive(BinWrite, Debug)]
+    #[bw(repr = u8)]
+    struct Test {
+        a: u8,
+    }
+
+    impl From<&Test> for u8 {
+        fn from(t: &Test) -> Self {
+            t.a
+        }
+    }
+}
+
+#[test]
+fn map_repr_struct_field() {
     #[derive(BinWrite, Debug)]
     #[bw(big)]
     struct Test {

--- a/binrw/tests/ui/invalid_keyword_enum.stderr
+++ b/binrw/tests/ui/invalid_keyword_enum.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `return_all_errors`, `return_unexpected_error`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `return_all_errors`, `return_unexpected_error`
  --> $DIR/invalid_keyword_enum.rs:4:6
   |
 4 | #[br(invalid_enum_keyword)]

--- a/binrw/tests/ui/invalid_keyword_enum_variant.stderr
+++ b/binrw/tests/ui/invalid_keyword_enum_variant.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
  --> $DIR/invalid_keyword_enum_variant.rs:5:10
   |
 5 |     #[br(invalid_enum_variant_keyword)]

--- a/binrw/tests/ui/invalid_keyword_struct.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
  --> $DIR/invalid_keyword_struct.rs:4:6
   |
 4 | #[br(invalid_struct_keyword)]

--- a/binrw/tests/ui/invalid_keyword_struct_field.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct_field.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
  --> $DIR/invalid_keyword_struct_field.rs:5:10
   |
 5 |     #[br(invalid_struct_field_keyword)]

--- a/binrw/tests/ui/invalid_keyword_with_imports.stderr
+++ b/binrw/tests/ui/invalid_keyword_with_imports.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
  --> $DIR/invalid_keyword_with_imports.rs:5:6
   |
 5 | #[br(invalid_struct_keyword)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
  --> $DIR/non_blocking_errors.rs:6:6
   |
 6 | #[br(invalid_keyword_struct)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -4,13 +4,13 @@ error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`
 6 | #[br(invalid_keyword_struct)]
   |      ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
  --> $DIR/non_blocking_errors.rs:8:10
   |
 8 |     #[br(invalid_keyword_struct_field_a)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
   --> $DIR/non_blocking_errors.rs:10:10
    |
 10 |     #[br(invalid_keyword_struct_field_b)]

--- a/binrw_derive/src/codegen/write_options.rs
+++ b/binrw_derive/src/codegen/write_options.rs
@@ -87,3 +87,14 @@ fn get_assertions(assertions: &[Assert]) -> impl Iterator<Item = TokenStream> + 
         },
     )
 }
+
+fn get_map_err(pos: IdentStr) -> TokenStream {
+    quote! {
+        .map_err(|e| {
+            #BIN_ERROR::Custom {
+                pos: #pos,
+                err: Box::new(e) as _,
+            }
+        })
+    }
+}

--- a/binrw_derive/src/codegen/write_options.rs
+++ b/binrw_derive/src/codegen/write_options.rs
@@ -24,10 +24,13 @@ pub(crate) fn generate(input: &Input, derive_input: &syn::DeriveInput) -> TokenS
             Input::UnitOnlyEnum(e) => generate_unit_enum(input, name, e),
         },
         Map::Try(map) | Map::Map(map) => {
-            let try_op = matches!(input.map(), Map::Try(_)).then(|| quote! { ? });
+            let map_try = matches!(input.map(), Map::Try(_)).then(|| {
+                let map_err = get_map_err(POS);
+                quote! { #map_err? }
+            });
             let write_data = quote! {
                 #WRITE_METHOD(
-                    &((#map)(self) #try_op),
+                    &((#map)(self) #map_try),
                     #WRITER,
                     #OPT,
                     ()

--- a/binrw_derive/src/parser/read/attrs.rs
+++ b/binrw_derive/src/parser/read/attrs.rs
@@ -12,6 +12,8 @@ use syn::{
     Expr, Token,
 };
 
+use core::ops::Deref;
+
 pub struct ReadOnlyAttr<T>(pub T);
 
 impl<T: KeywordToken> KeywordToken for ReadOnlyAttr<T> {
@@ -25,6 +27,19 @@ impl<T: KeywordToken> KeywordToken for ReadOnlyAttr<T> {
 impl<T: Parse> Parse for ReadOnlyAttr<T> {
     fn parse(buf: &ParseBuffer<'_>) -> Result<Self, syn::Error> {
         T::parse(buf).map(|x| ReadOnlyAttr(x))
+    }
+}
+
+impl<T: Into<TokenStream>> From<ReadOnlyAttr<T>> for TokenStream {
+    fn from(r: ReadOnlyAttr<T>) -> Self {
+        r.0.into()
+    }
+}
+
+impl<T> Deref for ReadOnlyAttr<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -58,7 +73,7 @@ pub(crate) type PadSizeTo = MetaExpr<kw::pad_size_to>;
 pub(crate) type ParseWith = MetaExpr<kw::parse_with>;
 pub(crate) type PostProcessNow = MetaVoid<kw::postprocess_now>;
 pub(crate) type PreAssert = AssertLike<kw::pre_assert>;
-pub(crate) type Repr = MetaType<kw::repr>;
+pub(crate) type Repr = ReadOnlyAttr<MetaType<kw::repr>>;
 pub(crate) type RestorePosition = MetaVoid<kw::restore_position>;
 pub(crate) type ReturnAllErrors = MetaVoid<kw::return_all_errors>;
 pub(crate) type ReturnUnexpectedError = MetaVoid<kw::return_unexpected_error>;

--- a/binrw_derive/src/parser/read/field_level_attrs.rs
+++ b/binrw_derive/src/parser/read/field_level_attrs.rs
@@ -22,7 +22,7 @@ attr_struct! {
         pub(crate) field: syn::Field,
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,

--- a/binrw_derive/src/parser/read/top_level_attrs.rs
+++ b/binrw_derive/src/parser/read/top_level_attrs.rs
@@ -142,7 +142,7 @@ attr_struct! {
         pub(crate) temp_legal: bool,
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,
@@ -201,7 +201,7 @@ attr_struct! {
         pub(crate) ident: Option<syn::Ident>,
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,

--- a/binrw_derive/src/parser/types/map.rs
+++ b/binrw_derive/src/parser/types/map.rs
@@ -1,6 +1,6 @@
-use crate::parser::{read::attrs, KeywordToken, TrySet};
+use crate::parser::{read, read::attrs, write, KeywordToken, TrySet};
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug)]
@@ -39,6 +39,20 @@ impl From<attrs::Map> for Map {
 impl From<attrs::TryMap> for Map {
     fn from(try_map: attrs::TryMap) -> Self {
         Self::Try(try_map.value.to_token_stream())
+    }
+}
+
+impl From<read::attrs::Repr> for Map {
+    fn from(repr: read::attrs::Repr) -> Self {
+        let ty = repr.value.to_token_stream();
+        Self::Try(quote! { <#ty as core::convert::TryInto<_>>::try_into })
+    }
+}
+
+impl From<write::attrs::Repr> for Map {
+    fn from(repr: write::attrs::Repr) -> Self {
+        let ty = repr.value.to_token_stream();
+        Self::Try(quote! { <#ty as core::convert::TryFrom<_>>::try_from })
     }
 }
 

--- a/binrw_derive/src/parser/write/attrs.rs
+++ b/binrw_derive/src/parser/write/attrs.rs
@@ -12,6 +12,8 @@ use syn::{
     Expr,
 };
 
+use core::ops::Deref;
+
 pub struct WriteOnlyAttr<T>(pub T);
 
 impl<T: KeywordToken> KeywordToken for WriteOnlyAttr<T> {
@@ -25,6 +27,19 @@ impl<T: KeywordToken> KeywordToken for WriteOnlyAttr<T> {
 impl<T: Parse> Parse for WriteOnlyAttr<T> {
     fn parse(buf: &ParseBuffer<'_>) -> Result<Self, syn::Error> {
         T::parse(buf).map(|x| WriteOnlyAttr(x))
+    }
+}
+
+impl<T: Into<TokenStream>> From<WriteOnlyAttr<T>> for TokenStream {
+    fn from(w: WriteOnlyAttr<T>) -> Self {
+        w.0.into()
+    }
+}
+
+impl<T> Deref for WriteOnlyAttr<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -51,7 +66,7 @@ pub(crate) type PadBefore = MetaExpr<kw::pad_before>;
 pub(crate) type PadSizeTo = MetaExpr<kw::pad_size_to>;
 pub(crate) type WriteWith = MetaExpr<kw::write_with>;
 pub(crate) type PreAssert = AssertLike<kw::pre_assert>;
-pub(crate) type Repr = MetaType<kw::repr>;
+pub(crate) type Repr = WriteOnlyAttr<MetaType<kw::repr>>;
 pub(crate) type RestorePosition = MetaVoid<kw::restore_position>;
 pub(crate) type ReturnAllErrors = MetaVoid<kw::return_all_errors>;
 pub(crate) type ReturnUnexpectedError = MetaVoid<kw::return_unexpected_error>;

--- a/binrw_derive/src/parser/write/field_level_attrs.rs
+++ b/binrw_derive/src/parser/write/field_level_attrs.rs
@@ -22,7 +22,7 @@ attr_struct! {
         pub(crate) field: syn::Field,
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,

--- a/binrw_derive/src/parser/write/top_level_attrs.rs
+++ b/binrw_derive/src/parser/write/top_level_attrs.rs
@@ -138,7 +138,7 @@ attr_struct! {
         pub(crate) temp_legal: bool,
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,
@@ -202,7 +202,7 @@ attr_struct! {
     pub(crate) struct Enum {
         #[from(Big, Little, IsBig, IsLittle)]
         pub(crate) endian: CondEndian,
-        #[from(Map, TryMap)]
+        #[from(Map, TryMap, Repr)]
         pub(crate) map: Map,
         #[from(Magic)]
         pub(crate) magic: Magic,


### PR DESCRIPTION
Use the `binrw::Error::Custom` variant to return error.
Meant to fix #92.

- [x] field/variant-level `repr`
- [ ] dedicated error variant?
- [x] top-level `repr` for structs/enums
- [ ] write documentation