### PR TITLE
attempt fix for https://github.com/jam1garner/binrw/issues/125

### DIFF
--- a/binrw/src/error/mod.rs
+++ b/binrw/src/error/mod.rs
@@ -186,7 +186,11 @@ impl Error {
     /// Check if the [root cause][`Self::root_cause`] of this error is an [`Error::Io`] and an
     /// [`io::ErrorKind::UnexpectedEof`].
     pub fn is_eof(&self) -> bool {
-        if let Error::EnumErrors { pos: _, variant_errors } = self {
+        if let Error::EnumErrors {
+            pos: _,
+            variant_errors,
+        } = self
+        {
             variant_errors.iter().all(|(_, err)| err.is_eof())
         } else {
             matches!(

--- a/binrw/src/error/mod.rs
+++ b/binrw/src/error/mod.rs
@@ -186,7 +186,14 @@ impl Error {
     /// Check if the [root cause][`Self::root_cause`] of this error is an [`Error::Io`] and an
     /// [`io::ErrorKind::UnexpectedEof`].
     pub fn is_eof(&self) -> bool {
-        matches!(self.root_cause(), Error::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof)
+        if let Error::EnumErrors { pos: _, variant_errors } = self {
+            variant_errors.iter().all(|(_, err)| err.is_eof())
+        } else {
+            matches!(
+                self.root_cause(),
+                Error::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof,
+            )
+        }
     }
 
     /// Returns a reference to the boxed error object if this `Error` is a


### PR DESCRIPTION
Implemented the suggested fix: https://github.com/jam1garner/binrw/issues/125#issuecomment-1142389738

Resolves the error observed in https://github.com/qtfkwk/br-eof-poc by simply changing its Cargo.toml to use a local clone with the path:

```diff
diff --git a/Cargo.toml b/Cargo.toml
index 6ec32bf..507f5b4 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 #binread = "2.2.0"
-binrw = "0.8.4"
+#binrw = "0.8.4"
+binrw = { path = "../../github.com/qtfkwk/binrw/binrw" }
```

Checked the `CONTRIBUTING.md` and don't believe this change requires any change to the doc or interface except to say that it makes the `is_eof` function check if all the variant errors are `UnexpectedEof` if the error is an `EnumErrors`.