### PR TITLE
NonZeroXXX integers

### DIFF
--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -65,7 +65,7 @@ fn unexpected_zero_num() -> Error {
     ))
 }
 
-macro_rules! binread_tuple_impl {
+macro_rules! binread_nonzero_impl {
     ($($Ty:ty, $Int:ty),* $(,)?) => {
         $(
             impl BinRead for $Ty {
@@ -86,7 +86,7 @@ macro_rules! binread_tuple_impl {
     }
 }
 
-binread_tuple_impl! {
+binread_nonzero_impl! {
     NonZeroU8, u8, NonZeroU16, u16, NonZeroU32, u32, NonZeroU64, u64, NonZeroU128, u128,
     NonZeroI8, i8, NonZeroI16, i16, NonZeroI32, i32, NonZeroI64, i64, NonZeroI128, i128,
 }

--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -5,8 +5,8 @@ use crate::{
 use core::any::Any;
 use core::convert::TryInto;
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
-    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8,
 };
 
 use binrw_derive::BinrwNamedArgs;

--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -2,11 +2,11 @@
 //! a file.
 
 use core::fmt;
-use core::ops::{Deref, DerefMut};
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
-    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8,
 };
+use core::ops::{Deref, DerefMut};
 
 use crate::{
     io::{Read, Seek, SeekFrom},
@@ -247,8 +247,16 @@ macro_rules! impl_into_seek_from_for_non_zero {
 }
 
 impl_into_seek_from_for_non_zero!(
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
-    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8
+    NonZeroI128,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroI8,
+    NonZeroU128,
+    NonZeroU16,
+    NonZeroU32,
+    NonZeroU64,
+    NonZeroU8
 );
 
 /// Dereferences the value.

--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -3,6 +3,10 @@
 
 use core::fmt;
 use core::ops::{Deref, DerefMut};
+use core::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
+    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+};
 
 use crate::{
     io::{Read, Seek, SeekFrom},
@@ -61,6 +65,17 @@ pub type FilePtr32<T> = FilePtr<u32, T>;
 pub type FilePtr64<T> = FilePtr<u64, T>;
 /// A type alias for [`FilePtr`] with 128-bit offsets.
 pub type FilePtr128<T> = FilePtr<u128, T>;
+
+/// A type alias for [`FilePtr`] with non-zero 8-bit offsets.
+pub type NonZeroFilePtr8<T> = FilePtr<NonZeroU8, T>;
+/// A type alias for [`FilePtr`] with non-zero 16-bit offsets.
+pub type NonZeroFilePtr16<T> = FilePtr<NonZeroU16, T>;
+/// A type alias for [`FilePtr`] with non-zero  32-bit offsets.
+pub type NonZeroFilePtr32<T> = FilePtr<NonZeroU32, T>;
+/// A type alias for [`FilePtr`] with non-zero  64-bit offsets.
+pub type NonZeroFilePtr64<T> = FilePtr<NonZeroU64, T>;
+/// A type alias for [`FilePtr`] with non-zero  128-bit offsets.
+pub type NonZeroFilePtr128<T> = FilePtr<NonZeroU128, T>;
 
 impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, BR: BinRead> BinRead for FilePtr<Ptr, BR> {
     type Args = BR::Args;
@@ -218,6 +233,23 @@ macro_rules! impl_into_seek_from {
 }
 
 impl_into_seek_from!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128);
+
+macro_rules! impl_into_seek_from_for_non_zero {
+    ($($t:ty),*) => {
+        $(
+            impl IntoSeekFrom for $t {
+                fn into_seek_from(self) -> SeekFrom {
+                    self.get().into_seek_from()
+                }
+            }
+        )*
+    };
+}
+
+impl_into_seek_from_for_non_zero!(
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
+    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8
+);
 
 /// Dereferences the value.
 ///


### PR DESCRIPTION
Hi there!
Thanks for your job, it's awesome one! 
Between this and then I was thinking about non-zero `FilePtr's` as frequently used: zero describes nothing, otherwise go by location. But there're no such variants of implementations. So, I made my one. Also, it's usable for solving #132. 

P. S. `FilePtr` for now is able to use `#[br(try)]` resulting in `Option<NonZeroFilePtrXX<T>>` when offset is zero