### PR TITLE
Rewrite string APIs to use standard Rust traits

### DIFF
--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -115,7 +115,7 @@
 //! let mut data = Cursor::new(b"DOG\x02\x00\x01\x00\x12\0\0Rudy\0");
 //! let dog = Dog::read(&mut data).unwrap();
 //! assert_eq!(dog.bone_piles, &[0x1, 0x12]);
-//! assert_eq!(dog.name.into_string(), "Rudy")
+//! assert_eq!(dog.name.to_string(), "Rudy")
 //! ```
 //!
 //! Directives can also reference earlier fields by name. For tuple types,

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -185,7 +185,7 @@ fn move_temp_field() {
     assert_eq!(
         Foo::read(&mut Cursor::new(b"hello\0goodbyte\0")).unwrap(),
         Foo {
-            bar: binrw::NullString::from_string(String::from("hello")),
+            bar: binrw::NullString::from("hello"),
         }
     );
 }

--- a/binrw/tests/strings.rs
+++ b/binrw/tests/strings.rs
@@ -1,33 +1,64 @@
 #[test]
 fn null_wide_strings() {
     use binrw::{io::Cursor, BinReaderExt, NullWideString};
-
-    const WIDE_STRINGS: &[u8] = b"w\0i\0d\0e\0 \0s\0t\0r\0i\0n\0g\0s\0\0\0";
-    const ARE_ENDIAN_DEPENDENT: &[u8] =
-        b"\0a\0r\0e\0 \0e\0n\0d\0i\0a\0n\0 \0d\0e\0p\0e\0n\0d\0e\0n\0t\0\0";
-
-    let mut wide_strings = Cursor::new(WIDE_STRINGS);
-    let mut are_endian_dependent = Cursor::new(ARE_ENDIAN_DEPENDENT);
-
-    let wide_strings: NullWideString = wide_strings.read_le().unwrap();
-    let are_endian_dependent: NullWideString = are_endian_dependent.read_be().unwrap();
+    use core::convert::TryFrom;
 
     assert_eq!(
-        // notice: read_le
-        wide_strings.into_string(),
+        Cursor::new(b"w\0i\0d\0e\0 \0s\0t\0r\0i\0n\0g\0s\0\0\0")
+            .read_le::<NullWideString>()
+            .unwrap()
+            .to_string(),
         "wide strings"
     );
 
     assert_eq!(
-        // notice: read_be
-        are_endian_dependent.into_string(),
+        Cursor::new(b"\0a\0r\0e\0 \0e\0n\0d\0i\0a\0n\0 \0d\0e\0p\0e\0n\0d\0e\0n\0t\0\0")
+            .read_be::<NullWideString>()
+            .unwrap()
+            .to_string(),
         "are endian dependent"
     );
+
+    assert_eq!(
+        format!(
+            "{:?}",
+            Cursor::new(b"d\0e\0b\0u\0g\0\x3a\x26\n\0\0\0")
+                .read_le::<NullWideString>()
+                .unwrap()
+        ),
+        "NullWideString(\"debug☺\\n\")"
+    );
+
+    assert_eq!(
+        format!(
+            "{:?}",
+            Cursor::new(b"b\0a\0d\0 \0\0\xdc\0\xdc \0s\0u\0r\0r\0o\0g\0a\0t\0e\0\0\0")
+                .read_le::<NullWideString>()
+                .unwrap()
+        ),
+        "NullWideString(\"bad \u{FFFD}\u{FFFD} surrogate\")"
+    );
+
+    // Default/Deref/DerefMut
+    let mut s = NullWideString::default();
+    s.extend_from_slice(&[b'h'.into(), b'e'.into(), b'y'.into()]);
+    assert_eq!(&s[0..2], &[b'h'.into(), b'e'.into()]);
+
+    // Clone/TryFrom
+    let t = String::try_from(s.clone()).unwrap();
+    assert_eq!(t, "hey");
+    s.push(0xdc00);
+    String::try_from(s).expect_err("accepted bad data");
+
+    // From
+    let s = NullWideString::from(t.clone());
+    assert_eq!(Vec::from(s), t.encode_utf16().collect::<Vec<_>>());
 }
 
 #[test]
 fn null_strings() {
     use binrw::{io::Cursor, BinReaderExt, NullString};
+    use core::convert::TryFrom;
 
     let mut null_separated_strings =
         Cursor::new(b"null terminated strings? in my system's language?\0no thanks\0");
@@ -36,7 +67,7 @@ fn null_strings() {
         null_separated_strings
             .read_be::<NullString>()
             .unwrap()
-            .into_string(),
+            .to_string(),
         "null terminated strings? in my system's language?"
     );
 
@@ -44,9 +75,54 @@ fn null_strings() {
         null_separated_strings
             .read_be::<NullString>()
             .unwrap()
-            .into_string(),
+            .to_string(),
         "no thanks"
     );
+
+    assert_eq!(
+        format!(
+            "{:?}",
+            Cursor::new(b"debug\xe2\x98\xba\n\0")
+                .read_be::<NullString>()
+                .unwrap()
+        ),
+        "NullString(\"debug☺\\n\")"
+    );
+
+    assert_eq!(
+        format!(
+            "{:?}",
+            Cursor::new(b"bad \xfe utf8 \xfe\0")
+                .read_be::<NullString>()
+                .unwrap()
+        ),
+        "NullString(\"bad \u{FFFD} utf8 \u{FFFD}\")"
+    );
+
+    assert_eq!(
+        format!(
+            "{:?}",
+            Cursor::new(b"truncated\xe2\0")
+                .read_be::<NullString>()
+                .unwrap()
+        ),
+        "NullString(\"truncated\u{FFFD}\")"
+    );
+
+    // Default/Deref/DerefMut
+    let mut s = NullString::default();
+    s.extend_from_slice(b"hey");
+    assert_eq!(&s[0..2], b"he");
+
+    // Clone/TryFrom
+    let t = String::try_from(s.clone()).unwrap();
+    assert_eq!(t, "hey");
+    s.extend_from_slice(b"\xe2");
+    String::try_from(s).expect_err("accepted bad data");
+
+    // From
+    let s = NullString::from(t.clone());
+    assert_eq!(Vec::from(s), t.as_bytes());
 }
 
 #[test]
@@ -54,14 +130,14 @@ fn null_string_round_trip() {
     use binrw::{io::Cursor, BinReaderExt, BinWriterExt, NullString};
 
     let data = "test test test";
-    let s = NullString::from_string(String::from(data));
+    let s = NullString::from(data);
 
     let mut x = Cursor::new(Vec::new());
     x.write_be(&s).unwrap();
 
     let s2: NullString = Cursor::new(x.into_inner()).read_be().unwrap();
 
-    assert_eq!(&s2.into_string(), data);
+    assert_eq!(&s2.to_string(), data);
 }
 
 #[test]
@@ -69,12 +145,12 @@ fn null_wide_string_round_trip() {
     use binrw::{io::Cursor, BinReaderExt, BinWriterExt, NullWideString};
 
     let data = "test test test";
-    let s = NullWideString::from_string(String::from(data));
+    let s = NullWideString::from(data);
 
     let mut x = Cursor::new(Vec::new());
     x.write_be(&s).unwrap();
 
     let s2: NullWideString = Cursor::new(x.into_inner()).read_be().unwrap();
 
-    assert_eq!(&s2.into_string(), data);
+    assert_eq!(&s2.to_string(), data);
 }


### PR DESCRIPTION
Imagine a rewritten null-terminated string API that is all trait implementations. Nothing but the awesomely sweet taste of all traits. Oops! All traits.

This is an API breaking change. The old functions could be retained with deprecation notices, but binrw is pre-1.0, that sounds pretty boring or whatever, so I just deleted them.