### PR TITLE
Allow use of unsized readers and writers

### DIFF
--- a/binrw/src/attribute.rs
+++ b/binrw/src/attribute.rs
@@ -1037,7 +1037,7 @@
 //! ```
 //! # use binrw::{prelude::*, io::*, ReadOptions};
 //! # use std::collections::HashMap;
-//! fn custom_parser<R: Read + Seek>(reader: &mut R, ro: &ReadOptions, _: ())
+//! fn custom_parser<R: Read + Seek + ?Sized>(reader: &mut R, ro: &ReadOptions, _: ())
 //!     -> BinResult<HashMap<u16, u16>>
 //! {
 //!     let mut map = HashMap::new();
@@ -1065,7 +1065,7 @@
 //! ```
 //! # use binrw::{prelude::*, io::*, WriteOptions};
 //! # use std::collections::BTreeMap;
-//! fn custom_writer<R: Write + Seek>(
+//! fn custom_writer<R: Write + Seek + ?Sized>(
 //!     map: &BTreeMap<u16, u16>,
 //!     writer: &mut R,
 //!     wo: &WriteOptions,

--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -20,7 +20,7 @@ macro_rules! binread_impl {
             impl BinRead for $type_name {
                 type Args = ();
 
-                fn read_options<R: Read + Seek>(reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<Self> {
+                fn read_options<R: Read + Seek + ?Sized>(reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<Self> {
                     let mut val = [0; core::mem::size_of::<$type_name>()];
                     let pos = reader.stream_position()?;
 
@@ -71,7 +71,7 @@ macro_rules! binread_nonzero_impl {
             impl BinRead for $Ty {
                 type Args = ();
 
-                fn read_options<R: Read + Seek>(
+                fn read_options<R: Read + Seek + ?Sized>(
                     reader: &mut R,
                     options: &ReadOptions,
                     _: Self::Args,
@@ -159,7 +159,7 @@ pub struct VecArgs<B> {
 impl<B: BinRead> BinRead for Vec<B> {
     type Args = VecArgs<B::Args>;
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: Self::Args,
@@ -191,7 +191,7 @@ impl<B: BinRead> BinRead for Vec<B> {
         args: Self::Args,
     ) -> BinResult<()>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
     {
         for val in self.iter_mut() {
             val.after_parse(reader, ro, args.inner.clone())?;
@@ -204,7 +204,7 @@ impl<B: BinRead> BinRead for Vec<B> {
 impl<B: BinRead, const N: usize> BinRead for [B; N] {
     type Args = B::Args;
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: Self::Args,
@@ -214,7 +214,7 @@ impl<B: BinRead, const N: usize> BinRead for [B; N] {
 
     fn after_parse<R>(&mut self, reader: &mut R, ro: &ReadOptions, args: B::Args) -> BinResult<()>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
     {
         for val in self.iter_mut() {
             val.after_parse(reader, ro, args.clone())?;
@@ -230,7 +230,7 @@ macro_rules! binread_tuple_impl {
         impl<$type1: BinRead<Args=()>, $($types: BinRead<Args=()>),*> BinRead for ($type1, $($types),*) {
             type Args = ();
 
-            fn read_options<R: Read + Seek>(reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<Self> {
+            fn read_options<R: Read + Seek + ?Sized>(reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<Self> {
                 Ok((
                     BinRead::read_options(reader, options, ())?,
                     $(
@@ -239,7 +239,7 @@ macro_rules! binread_tuple_impl {
                 ))
             }
 
-            fn after_parse<R: Read + Seek>(&mut self, reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<()> {
+            fn after_parse<R: Read + Seek + ?Sized>(&mut self, reader: &mut R, options: &ReadOptions, _: Self::Args) -> BinResult<()> {
                 let ($type1, $(
                     $types
                 ),*) = self;
@@ -267,7 +267,11 @@ binread_tuple_impl!(
 impl BinRead for () {
     type Args = ();
 
-    fn read_options<R: Read + Seek>(_: &mut R, _: &ReadOptions, _: Self::Args) -> BinResult<Self> {
+    fn read_options<R: Read + Seek + ?Sized>(
+        _: &mut R,
+        _: &ReadOptions,
+        _: Self::Args,
+    ) -> BinResult<Self> {
         Ok(())
     }
 }
@@ -275,7 +279,7 @@ impl BinRead for () {
 impl<T: BinRead> BinRead for Box<T> {
     type Args = T::Args;
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: Self::Args,
@@ -287,7 +291,7 @@ impl<T: BinRead> BinRead for Box<T> {
 impl<T: BinRead> BinRead for Option<T> {
     type Args = T::Args;
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: Self::Args,
@@ -302,7 +306,7 @@ impl<T: BinRead> BinRead for Option<T> {
         args: Self::Args,
     ) -> BinResult<()>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
     {
         match self {
             Some(val) => val.after_parse(reader, ro, args),
@@ -314,7 +318,11 @@ impl<T: BinRead> BinRead for Option<T> {
 impl<T: 'static> BinRead for core::marker::PhantomData<T> {
     type Args = ();
 
-    fn read_options<R: Read + Seek>(_: &mut R, _: &ReadOptions, _: Self::Args) -> BinResult<Self> {
+    fn read_options<R: Read + Seek + ?Sized>(
+        _: &mut R,
+        _: &ReadOptions,
+        _: Self::Args,
+    ) -> BinResult<Self> {
         Ok(core::marker::PhantomData)
     }
 }

--- a/binrw/src/binread/mod.rs
+++ b/binrw/src/binread/mod.rs
@@ -52,7 +52,7 @@ pub trait BinRead: Sized + 'static {
     type Args: Clone;
 
     /// Read `Self` from the reader using default arguments.
-    fn read<R: Read + Seek>(reader: &mut R) -> BinResult<Self>
+    fn read<R: Read + Seek + ?Sized>(reader: &mut R) -> BinResult<Self>
     where
         Self::Args: Default,
     {
@@ -66,7 +66,7 @@ pub trait BinRead: Sized + 'static {
 
     /// Read `Self` from the reader using the given [`ReadOptions`] and
     /// arguments.
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: Self::Args,
@@ -74,7 +74,7 @@ pub trait BinRead: Sized + 'static {
 
     /// Runs any post-processing steps required to finalize construction of the
     /// object.
-    fn after_parse<R: Read + Seek>(
+    fn after_parse<R: Read + Seek + ?Sized>(
         &mut self,
         _: &mut R,
         _: &ReadOptions,

--- a/binrw/src/binwrite/impls.rs
+++ b/binrw/src/binwrite/impls.rs
@@ -18,7 +18,7 @@ macro_rules! binwrite_num_impl {
             impl BinWrite for $type_name {
                 type Args = ();
 
-                fn write_options<W: Write + Seek>(
+                fn write_options<W: Write + Seek + ?Sized>(
                     &self,
                     writer: &mut W,
                     options: &WriteOptions,
@@ -43,7 +43,7 @@ macro_rules! binwrite_nonzero_num_impl {
             impl BinWrite for $non_zero_type {
                 type Args = ();
 
-                fn write_options<W: Write + Seek>(
+                fn write_options<W: Write + Seek + ?Sized>(
                     &self,
                     writer: &mut W,
                     options: &WriteOptions,
@@ -82,7 +82,7 @@ binwrite_nonzero_num_impl!(
 impl<T: BinWrite + 'static, const N: usize> BinWrite for [T; N] {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -103,7 +103,7 @@ impl<T: BinWrite + 'static, const N: usize> BinWrite for [T; N] {
 impl<T: BinWrite> BinWrite for [T] {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -120,7 +120,7 @@ impl<T: BinWrite> BinWrite for [T] {
 impl<T: BinWrite + 'static> BinWrite for Vec<T> {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -145,7 +145,7 @@ impl<T: BinWrite + 'static> BinWrite for Vec<T> {
 impl<T: BinWrite + ?Sized> BinWrite for &T {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -158,7 +158,7 @@ impl<T: BinWrite + ?Sized> BinWrite for &T {
 impl<T: BinWrite + ?Sized + 'static> BinWrite for Box<T> {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -177,7 +177,7 @@ impl<T: BinWrite + ?Sized + 'static> BinWrite for Box<T> {
 impl<T: BinWrite> BinWrite for Option<T> {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,
@@ -193,7 +193,7 @@ impl<T: BinWrite> BinWrite for Option<T> {
 impl<T: BinWrite> BinWrite for PhantomData<T> {
     type Args = T::Args;
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         _: &mut W,
         _: &WriteOptions,
@@ -210,7 +210,7 @@ impl<T: BinWrite> BinWrite for PhantomData<T> {
 impl BinWrite for () {
     type Args = ();
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         _: &mut W,
         _: &WriteOptions,
@@ -228,7 +228,7 @@ macro_rules! binwrite_tuple_impl {
         > BinWrite for ($type1, $($types),*) {
             type Args = ();
 
-            fn write_options<W: Write + Seek>(
+            fn write_options<W: Write + Seek + ?Sized>(
                 &self,
                 writer: &mut W,
                 options: &WriteOptions,

--- a/binrw/src/binwrite/mod.rs
+++ b/binrw/src/binwrite/mod.rs
@@ -14,7 +14,7 @@ pub trait BinWrite {
     type Args: Clone;
 
     /// Write a type to a writer while assuming no arguments are needed.
-    fn write_to<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
+    fn write_to<W: Write + Seek + ?Sized>(&self, writer: &mut W) -> BinResult<()>
     where
         Self::Args: Default,
     {
@@ -22,13 +22,17 @@ pub trait BinWrite {
     }
 
     /// Write the type to a writer while providing the default [`WriteOptions`]
-    fn write_with_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args) -> BinResult<()> {
+    fn write_with_args<W: Write + Seek + ?Sized>(
+        &self,
+        writer: &mut W,
+        args: Self::Args,
+    ) -> BinResult<()> {
         self.write_options(writer, &WriteOptions::default(), args)
     }
 
     /// Write the type to a writer, given the options on how to write it and the type-specific
     /// arguments
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &WriteOptions,

--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -84,7 +84,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, BR: BinRead> BinRead for FilePtr<Pt
     ///
     /// The actual value will not be read until
     /// [`after_parse()`](Self::after_parse) is called.
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         _: Self::Args,
@@ -98,7 +98,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, BR: BinRead> BinRead for FilePtr<Pt
     /// Finalizes the `FilePtr` by seeking to and reading the pointed-to value.
     fn after_parse<R>(&mut self, reader: &mut R, ro: &ReadOptions, args: BR::Args) -> BinResult<()>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
     {
         self.after_parse_with_parser(BR::read_options, BR::after_parse, reader, ro, args)
     }
@@ -113,7 +113,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
         args: Args,
     ) -> BinResult<Self>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
         Args: Clone,
         Parser: Fn(&mut R, &ReadOptions, Args) -> BinResult<T>,
         AfterParse: Fn(&mut T, &mut R, &ReadOptions, Args) -> BinResult<()>,
@@ -135,7 +135,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
         args: Args,
     ) -> BinResult<()>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
         Args: Clone,
         Parser: Fn(&mut R, &ReadOptions, Args) -> BinResult<T>,
         AfterParse: Fn(&mut T, &mut R, &ReadOptions, Args) -> BinResult<()>,
@@ -160,7 +160,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// value as the result.
     pub fn parse<R, Args>(reader: &mut R, options: &ReadOptions, args: Args) -> BinResult<T>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
         Args: Clone,
         T: BinRead<Args = Args>,
     {
@@ -176,7 +176,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// value as the result.
     pub fn parse_with<R, F, Args>(parser: F) -> impl Fn(&mut R, &ReadOptions, Args) -> BinResult<T>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
         Args: Clone,
         F: Fn(&mut R, &ReadOptions, Args) -> BinResult<T>,
     {
@@ -192,7 +192,7 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// as the result.
     pub fn with<R, F, Args>(parser: F) -> impl Fn(&mut R, &ReadOptions, Args) -> BinResult<Self>
     where
-        R: Read + Seek,
+        R: Read + Seek + ?Sized,
         Args: Clone,
         F: Fn(&mut R, &ReadOptions, Args) -> BinResult<T>,
     {

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -30,7 +30,7 @@ pub fn until<Reader, T, CondFn, Arg, Ret>(
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
     T: BinRead<Args = Arg>,
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     CondFn: Fn(&T) -> bool,
     Arg: Clone,
     Ret: core::iter::FromIterator<T>,
@@ -66,7 +66,7 @@ pub fn until_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
     read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     CondFn: Fn(&T) -> bool,
     Arg: Clone,
     ReadFn: Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<T>,
@@ -110,7 +110,7 @@ pub fn until_exclusive<Reader, T, CondFn, Arg, Ret>(
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
     T: BinRead<Args = Arg>,
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     CondFn: Fn(&T) -> bool,
     Arg: Clone,
     Ret: core::iter::FromIterator<T>,
@@ -146,7 +146,7 @@ pub fn until_exclusive_with<Reader, T, CondFn, Arg, ReadFn, Ret>(
     read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     CondFn: Fn(&T) -> bool,
     Arg: Clone,
     ReadFn: Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<T>,
@@ -191,7 +191,7 @@ pub fn until_eof<Reader, T, Arg, Ret>(
 ) -> BinResult<Ret>
 where
     T: BinRead<Args = Arg>,
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     Arg: Clone,
     Ret: core::iter::FromIterator<T>,
 {
@@ -225,7 +225,7 @@ pub fn until_eof_with<Reader, T, Arg, ReadFn, Ret>(
     read: ReadFn,
 ) -> impl Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<Ret>
 where
-    Reader: Read + Seek,
+    Reader: Read + Seek + ?Sized,
     Arg: Clone,
     ReadFn: Fn(&mut Reader, &ReadOptions, Arg) -> BinResult<T>,
     Ret: core::iter::FromIterator<T>,
@@ -277,7 +277,7 @@ fn not_enough_bytes<T>(_: T) -> Error {
 pub fn count<R, T, Arg, Ret>(n: usize) -> impl Fn(&mut R, &ReadOptions, Arg) -> BinResult<Ret>
 where
     T: BinRead<Args = Arg>,
-    R: Read + Seek,
+    R: Read + Seek + ?Sized,
     Arg: Clone,
     Ret: core::iter::FromIterator<T> + 'static,
 {
@@ -326,7 +326,7 @@ pub fn count_with<R, T, Arg, ReadFn, Ret>(
     read: ReadFn,
 ) -> impl Fn(&mut R, &ReadOptions, Arg) -> BinResult<Ret>
 where
-    R: Read + Seek,
+    R: Read + Seek + ?Sized,
     Arg: Clone,
     ReadFn: Fn(&mut R, &ReadOptions, Arg) -> BinResult<T>,
     Ret: core::iter::FromIterator<T> + 'static,

--- a/binrw/src/pos_value.rs
+++ b/binrw/src/pos_value.rs
@@ -32,7 +32,7 @@ pub struct PosValue<T> {
 impl<T: BinRead> BinRead for PosValue<T> {
     type Args = T::Args;
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: T::Args,
@@ -45,7 +45,7 @@ impl<T: BinRead> BinRead for PosValue<T> {
         })
     }
 
-    fn after_parse<R: Read + Seek>(
+    fn after_parse<R: Read + Seek + ?Sized>(
         &mut self,
         reader: &mut R,
         options: &ReadOptions,

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -55,7 +55,7 @@ where
 pub fn magic<R, B>(reader: &mut R, expected: B, options: &ReadOptions) -> BinResult<()>
 where
     B: BinRead<Args = ()> + core::fmt::Debug + PartialEq + Sync + Send + 'static,
-    R: io::Read + io::Seek,
+    R: io::Read + io::Seek + ?Sized,
 {
     let pos = reader.stream_position()?;
     let val = B::read_options(reader, options, ())?;
@@ -71,7 +71,7 @@ where
 
 pub fn parse_function_args_type_hint<R, Res, Args, F>(_: F, a: Args) -> Args
 where
-    R: crate::io::Read + Seek,
+    R: crate::io::Read + Seek + ?Sized,
     F: FnOnce(&mut R, &crate::ReadOptions, Args) -> crate::BinResult<Res>,
 {
     a
@@ -79,7 +79,7 @@ where
 
 pub fn write_function_args_type_hint<T, W, Args, F>(_: F, a: Args) -> Args
 where
-    W: Write + Seek,
+    W: Write + Seek + ?Sized,
     F: FnOnce(&T, &mut W, &crate::WriteOptions, Args) -> crate::BinResult<()>,
 {
     a
@@ -96,7 +96,7 @@ where
 pub fn write_fn_type_hint<T, WriterFn, Writer, Args>(x: WriterFn) -> WriterFn
 where
     Args: Clone,
-    Writer: Write + Seek,
+    Writer: Write + Seek + ?Sized,
     WriterFn: Fn(&T, &mut Writer, &WriteOptions, Args) -> BinResult<()>,
 {
     x
@@ -136,7 +136,7 @@ pub fn write_fn_map_output_type_hint<Input, Output, MapFn, Writer, WriteFn, Args
 where
     MapFn: FnOnce(Input) -> Output,
     Args: Clone,
-    Writer: Write + Seek,
+    Writer: Write + Seek + ?Sized,
     WriteFn: Fn(&Output, &mut Writer, &WriteOptions, Args) -> BinResult<()>,
 {
     func
@@ -150,13 +150,13 @@ where
     Error: CustomError,
     MapFn: FnOnce(Input) -> Result<Output, Error>,
     Args: Clone,
-    Writer: Write + Seek,
+    Writer: Write + Seek + ?Sized,
     WriteFn: Fn(&Output, &mut Writer, &WriteOptions, Args) -> BinResult<()>,
 {
     func
 }
 
-pub fn write_zeroes<W: Write>(writer: &mut W, count: u64) -> BinResult<()> {
+pub fn write_zeroes<W: Write + ?Sized>(writer: &mut W, count: u64) -> BinResult<()> {
     const BUF_SIZE: u64 = 0x20;
     const ZEROES: [u8; BUF_SIZE as usize] = [0u8; BUF_SIZE as usize];
 

--- a/binrw/src/punctuated.rs
+++ b/binrw/src/punctuated.rs
@@ -69,7 +69,7 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// # assert_eq!(*y.x, vec![3, 2, 1]);
     /// # assert_eq!(y.x.separators, vec![0, 1]);
     /// ```
-    pub fn separated<R: Read + Seek>(
+    pub fn separated<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: VecArgs<T::Args>,
@@ -91,7 +91,7 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// a trailing `P`.
     ///
     /// Requires a count to be passed via `#[br(count)]`.
-    pub fn separated_trailing<R: Read + Seek>(
+    pub fn separated_trailing<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         args: VecArgs<T::Args>,

--- a/binrw/src/strings.rs
+++ b/binrw/src/strings.rs
@@ -39,7 +39,7 @@ pub struct NullString(
 impl BinRead for NullString {
     type Args = ();
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         _: Self::Args,
@@ -59,7 +59,7 @@ impl BinRead for NullString {
 impl BinWrite for NullString {
     type Args = ();
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &crate::WriteOptions,
@@ -161,7 +161,7 @@ pub struct NullWideString(
 impl BinRead for NullWideString {
     type Args = ();
 
-    fn read_options<R: Read + Seek>(
+    fn read_options<R: Read + Seek + ?Sized>(
         reader: &mut R,
         options: &ReadOptions,
         _: Self::Args,
@@ -181,7 +181,7 @@ impl BinRead for NullWideString {
 impl BinWrite for NullWideString {
     type Args = ();
 
-    fn write_options<W: Write + Seek>(
+    fn write_options<W: Write + Seek + ?Sized>(
         &self,
         writer: &mut W,
         options: &crate::WriteOptions,

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -26,7 +26,7 @@ fn all_the_things() {
         calc_test: u32,
     }
 
-    fn read_offsets<R: Read + Seek>(
+    fn read_offsets<R: Read + Seek + ?Sized>(
         reader: &mut R,
         ro: &ReadOptions,
         _: (),

--- a/binrw/tests/derive/write/custom_writer.rs
+++ b/binrw/tests/derive/write/custom_writer.rs
@@ -10,7 +10,7 @@ fn custom_writer() {
         y: u16,
     }
 
-    fn custom_writer<W: binrw::io::Write + binrw::io::Seek>(
+    fn custom_writer<W: binrw::io::Write + binrw::io::Seek + ?Sized>(
         _this: &u16,
         writer: &mut W,
         _opts: &WriteOptions,

--- a/binrw_derive/src/codegen/mod.rs
+++ b/binrw_derive/src/codegen/mod.rs
@@ -46,7 +46,7 @@ pub(crate) fn generate_binread_impl(
         impl #impl_generics #BINREAD_TRAIT for #name #ty_generics #where_clause {
             type Args = #arg_type;
 
-            fn read_options<R: #READ_TRAIT + #SEEK_TRAIT>
+            fn read_options<R: #READ_TRAIT + #SEEK_TRAIT + ?Sized>
                 (#READER: &mut R, #OPT: &#READ_OPTIONS, #ARGS: Self::Args)
                 -> #BIN_RESULT<Self>
             {
@@ -87,7 +87,7 @@ pub(crate) fn generate_binwrite_impl(
         impl #impl_generics #BINWRITE_TRAIT for #name #ty_generics #where_clause {
             type Args = #arg_type;
 
-            fn write_options<W: #WRITE_TRAIT + #SEEK_TRAIT>(
+            fn write_options<W: #WRITE_TRAIT + #SEEK_TRAIT + ?Sized>(
                 &self,
                 #WRITER: &mut W,
                 #OPT: &#WRITE_OPTIONS,


### PR DESCRIPTION
This fixes #104, but also will require every custom implementation of read_options/write_options/parse_with/write_with to also change their constraints. I don’t know if I am smart enough to really say whether or not this is a good idea, but it was easy to do!