### PR TITLE
Add fake specialisations for more Vec types

### DIFF
--- a/binrw/Cargo.toml
+++ b/binrw/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/binrw"
 [dependencies]
 array-init = "2.0"
 binrw_derive = { version = "0.9.0", path = "../binrw_derive" }
+bytemuck = "1.12"
 
 [dev-dependencies]
 modular-bitfield = "0.11"

--- a/binrw/doc/performance.md
+++ b/binrw/doc/performance.md
@@ -46,5 +46,14 @@ types:
 | Type                 | Read | Write |
 |----------------------|------|-------|
 | `Vec<u8>`            | yes  | yes   |
+| `Vec<i8>`            | yes  | yes   |
+| `Vec<u16>`           | yes  | no    |
+| `Vec<i16>`           | yes  | no    |
+| `Vec<u32>`           | yes  | no    |
+| `Vec<i32>`           | yes  | no    |
+| `Vec<u64>`           | yes  | no    |
+| `Vec<i64>`           | yes  | no    |
+| `Vec<u128>`          | yes  | no    |
+| `Vec<i128>`          | yes  | no    |
 | `[u8; N]`            | no   | yes   |
 | `Box<[u8]>`          | no   | yes   |

--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -166,22 +166,24 @@ impl<B: BinRead> BinRead for Vec<B> {
     ) -> BinResult<Self> {
         let mut list = Self::with_capacity(args.count);
 
-        if let Some(bytes) = <dyn Any>::downcast_mut::<Vec<u8>>(&mut list) {
-            let byte_count = reader
-                .take(args.count.try_into().map_err(not_enough_bytes)?)
-                .read_to_end(bytes)?;
+        vec_fast_int!(try (i8 i16 u16 i32 u32 i64 u64 i128 u128) using (list, reader, options, args) else {
+            if let Some(bytes) = <dyn Any>::downcast_mut::<Vec<u8>>(&mut list) {
+                let byte_count = reader
+                    .take(args.count.try_into().map_err(not_enough_bytes)?)
+                    .read_to_end(bytes)?;
 
-            if byte_count == args.count {
-                Ok(list)
+                if byte_count == args.count {
+                    Ok(list)
+                } else {
+                    Err(not_enough_bytes(()))
+                }
             } else {
-                Err(not_enough_bytes(()))
+                for _ in 0..args.count {
+                    list.push(B::read_options(reader, options, args.inner.clone())?);
+                }
+                Ok(list)
             }
-        } else {
-            for _ in 0..args.count {
-                list.push(B::read_options(reader, options, args.inner.clone())?);
-            }
-            Ok(list)
-        }
+        })
     }
 
     fn after_parse<R>(
@@ -200,6 +202,34 @@ impl<B: BinRead> BinRead for Vec<B> {
         Ok(())
     }
 }
+
+macro_rules! vec_fast_int {
+    (try ($($Ty:ty)+) using ($list:expr, $reader:expr, $options:expr, $args:expr) else { $($else:tt)* }) => {
+        $(if let Some(list) = <dyn Any>::downcast_mut::<Vec<$Ty>>(&mut $list) {
+            // In benchmarks, this resize decreases performance by
+            // 27–40% relative to using `unsafe` to write directly to
+            // uninitialised memory, but nobody ever got fired for buying IBM
+            list.resize($args.count, 0);
+            $reader.read_exact(&mut bytemuck::cast_slice_mut::<_, u8>(list.as_mut_slice()))?;
+            if
+                core::mem::size_of::<$Ty>() != 1
+                && (
+                    (cfg!(target_endian = "big") && $options.endian() == Endian::Little)
+                    || (cfg!(target_endian = "little") && $options.endian() == Endian::Big)
+                )
+            {
+                for value in list.iter_mut() {
+                    *value = value.swap_bytes();
+                }
+            }
+            Ok($list)
+        } else)* {
+            $($else)*
+        }
+    }
+}
+
+use vec_fast_int;
 
 impl<B: BinRead, const N: usize> BinRead for [B; N] {
     type Args = B::Args;

--- a/binrw/src/binwrite/impls.rs
+++ b/binrw/src/binwrite/impls.rs
@@ -128,6 +128,8 @@ impl<T: BinWrite + 'static> BinWrite for Vec<T> {
     ) -> BinResult<()> {
         if let Some(this) = <dyn Any>::downcast_ref::<Vec<u8>>(self) {
             writer.write_all(this)?;
+        } else if let Some(this) = <dyn Any>::downcast_ref::<Vec<i8>>(self) {
+            writer.write_all(bytemuck::cast_slice(this.as_slice()))?;
         } else {
             for item in self {
                 T::write_options(item, writer, options, args.clone())?;


### PR DESCRIPTION
Adds specialisations for reading all `Vec<(integer)>` types and
writing `Vec<i8>`. Writing larger primitives is a bit more complex
so is deferred until, uh, later.