### PR TITLE
Enable and fix pedantic lints for runtime crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ parsers using ✨macro magic✨.
 
 ## Usage
 
-```rust
+```
 #[derive(BinRead)]
 #[br(magic = b"DOG", assert(name.len() != 0))]
 struct Dog {

--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -1035,7 +1035,7 @@ calling a function generator).
 ### Using a custom parser to generate a [`HashMap`](std::collections::HashMap)
 
 ```
-# use binrw::{prelude::*, io::*, ReadOptions};
+# use binrw::{prelude::*, io::{prelude::*, Cursor}, ReadOptions};
 # use std::collections::HashMap;
 fn custom_parser<R: Read + Seek>(reader: &mut R, ro: &ReadOptions, _: ())
     -> BinResult<HashMap<u16, u16>>
@@ -1063,7 +1063,7 @@ struct MyType {
 ### Using a custom serialiser to write a [`BTreeMap`](std::collections::BTreeMap)
 
 ```
-# use binrw::{prelude::*, io::*, WriteOptions};
+# use binrw::{prelude::*, io::{prelude::*, Cursor}, WriteOptions};
 # use std::collections::BTreeMap;
 fn custom_writer<R: Write + Seek>(
     map: &BTreeMap<u16, u16>,
@@ -1414,13 +1414,13 @@ explicitly declare the type of the data to be read in its first parameter
 and return a value which matches the type of the field.
 When using `#[bw(map)]` on a field, the map function will receive
 an immutable reference to the field value and must return a type which
-implements [`BinWrite`](binrw::BinWrite).</span>
+implements [`BinWrite`](crate::BinWrite).</span>
 <span class="br">When using `map` on a field, the map function must
 explicitly declare the type of the data to be read in its first parameter
 and return a value which matches the type of the field.</span>
 <span class="bw">When using `map` on a field, the map function will receive
 an immutable reference to the field value and must return a type which
-implements [`BinWrite`](binrw::BinWrite).</span>
+implements [`BinWrite`](crate::BinWrite).</span>
 The map function can be a plain function, closure, or call expression which
 returns a plain function or closure.
 
@@ -1430,11 +1430,11 @@ return a [`Result<T, E>`](Result) instead.
 When using `map` or `try_map` on a struct or enum, the map function
 <span class="brw">must return `Self` or `Result<Self, E>` for `BinRead`, and
 will receive an immutable reference to the entire object
-and must return a type that implements [`BinWrite`](binrw::BinWrite) for
+and must return a type that implements [`BinWrite`](crate::BinWrite) for
 `BinWrite`.</span>
 <span class="br">must return `Self` or `Result<Self, E>`.</span>
 <span class="bw">will receive an immutable reference to the entire object
-and must return a type that implements [`BinWrite`](binrw::BinWrite).</span>
+and must return a type that implements [`BinWrite`](crate::BinWrite).</span>
 
 Any <span class="br">earlier</span> field or [import](#arguments) can be
 referenced by the expression in the directive.

--- a/binrw/doc/index.md
+++ b/binrw/doc/index.md
@@ -82,7 +82,7 @@ like buffering and compression are efficient and easy to implement.
 `BinRead` also includes an [extension trait](BinReaderExt) for reading types
 directly from input objects:
 
-```rust
+```
 use binrw::{BinReaderExt, io::Cursor};
 
 let mut reader = Cursor::new(b"\x00\x0A");

--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -1,17 +1,15 @@
 use crate::{
     io::{self, Read, Seek, SeekFrom},
-    BinRead, BinResult, Endian, Error, ReadOptions,
+    BinRead, BinResult, BinrwNamedArgs, Endian, Error, ReadOptions,
 };
-use core::any::Any;
-use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
-    NonZeroU32, NonZeroU64, NonZeroU8,
-};
-
-use binrw_derive::BinrwNamedArgs;
-
-#[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, vec::Vec};
+use core::{
+    any::Any,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+        NonZeroU32, NonZeroU64, NonZeroU8,
+    },
+};
 
 macro_rules! binread_impl {
     ($($type_name:ty),*$(,)?) => {
@@ -94,7 +92,7 @@ binread_nonzero_impl! {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use binrw::{BinRead, io::Cursor};
 ///
 /// #[derive(BinRead, Debug, PartialEq)]
@@ -123,7 +121,7 @@ binread_nonzero_impl! {
 ///
 /// Inner types that don't require args take unit args.
 ///
-/// ```rust
+/// ```
 /// # use binrw::prelude::*;
 /// #[derive(BinRead)]
 /// struct Collection {

--- a/binrw/src/binread/mod.rs
+++ b/binrw/src/binread/mod.rs
@@ -1,13 +1,12 @@
+mod impls;
+mod options;
+
 use crate::{
     io::{Read, Seek},
     BinResult, Endian,
 };
-
-mod options;
-pub use options::*;
-
-mod impls;
 pub use impls::VecArgs;
+pub use options::ReadOptions;
 
 /// The `BinRead` trait reads data from streams and converts it into objects.
 ///
@@ -52,6 +51,10 @@ pub trait BinRead: Sized + 'static {
     type Args: Clone;
 
     /// Read `Self` from the reader using default arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read<R: Read + Seek>(reader: &mut R) -> BinResult<Self>
     where
         Self::Args: Default,
@@ -60,12 +63,20 @@ pub trait BinRead: Sized + 'static {
     }
 
     /// Read `Self` from the reader using the given arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_args<R: Read + Seek>(reader: &mut R, args: Self::Args) -> BinResult<Self> {
         Self::read_options(reader, &ReadOptions::default(), args)
     }
 
     /// Read `Self` from the reader using the given [`ReadOptions`] and
     /// arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_options<R: Read + Seek>(
         reader: &mut R,
         options: &ReadOptions,
@@ -74,6 +85,11 @@ pub trait BinRead: Sized + 'static {
 
     /// Runs any post-processing steps required to finalize construction of the
     /// object.
+    ///
+    /// # Errors
+    ///
+    /// If post-processing fails, an [`Error`](crate::Error) variant will be
+    /// returned.
     fn after_parse<R: Read + Seek>(
         &mut self,
         _: &mut R,
@@ -88,20 +104,22 @@ pub trait BinRead: Sized + 'static {
 ///
 /// # Examples
 ///
-/// ```rust
-/// use binrw::BinReaderExt;
-/// use binrw::endian::LE;
-/// use binrw::io::Cursor;
+/// ```
+/// use binrw::{BinReaderExt, Endian, io::Cursor};
 ///
 /// let mut reader = Cursor::new(b"\x07\0\0\0\xCC\0\0\x05");
 /// let x: u32 = reader.read_le().unwrap();
-/// let y: u16 = reader.read_type(LE).unwrap();
+/// let y: u16 = reader.read_type(Endian::Little).unwrap();
 /// let z = reader.read_be::<u16>().unwrap();
 ///
 /// assert_eq!((x, y, z), (7u32, 0xCCu16, 5u16));
 /// ```
 pub trait BinReaderExt: Read + Seek + Sized {
     /// Read `T` from the reader with the given byte order.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_type<T: BinRead>(&mut self, endian: Endian) -> BinResult<T>
     where
         T::Args: Default,
@@ -110,6 +128,10 @@ pub trait BinReaderExt: Read + Seek + Sized {
     }
 
     /// Read `T` from the reader assuming big-endian byte order.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_be<T: BinRead>(&mut self) -> BinResult<T>
     where
         T::Args: Default,
@@ -118,6 +140,10 @@ pub trait BinReaderExt: Read + Seek + Sized {
     }
 
     /// Read `T` from the reader assuming little-endian byte order.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_le<T: BinRead>(&mut self) -> BinResult<T>
     where
         T::Args: Default,
@@ -126,6 +152,10 @@ pub trait BinReaderExt: Read + Seek + Sized {
     }
 
     /// Read `T` from the reader assuming native-endian byte order.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_ne<T: BinRead>(&mut self) -> BinResult<T>
     where
         T::Args: Default,
@@ -134,6 +164,10 @@ pub trait BinReaderExt: Read + Seek + Sized {
     }
 
     /// Read `T` from the reader with the given byte order and arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_type_args<T: BinRead>(&mut self, endian: Endian, args: T::Args) -> BinResult<T> {
         let options = ReadOptions::default().with_endian(endian);
 
@@ -145,18 +179,30 @@ pub trait BinReaderExt: Read + Seek + Sized {
 
     /// Read `T` from the reader, assuming big-endian byte order, using the
     /// given arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_be_args<T: BinRead>(&mut self, args: T::Args) -> BinResult<T> {
         self.read_type_args(Endian::Big, args)
     }
 
     /// Read `T` from the reader, assuming little-endian byte order, using the
     /// given arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_le_args<T: BinRead>(&mut self, args: T::Args) -> BinResult<T> {
         self.read_type_args(Endian::Little, args)
     }
 
     /// Read `T` from the reader, assuming native-endian byte order, using the
     /// given arguments.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     fn read_ne_args<T: BinRead>(&mut self, args: T::Args) -> BinResult<T> {
         self.read_type_args(Endian::Native, args)
     }

--- a/binrw/src/binread/options.rs
+++ b/binrw/src/binread/options.rs
@@ -1,5 +1,3 @@
-#[cfg(all(doc, not(feature = "std")))]
-extern crate alloc;
 use super::Endian;
 #[cfg(all(doc, not(feature = "std")))]
 use alloc::vec::Vec;
@@ -21,7 +19,8 @@ pub struct ReadOptions {
 }
 
 impl ReadOptions {
-    /// Create a new ReadOptions with a given Endian
+    /// Creates a new `ReadOptions` with the given [endianness](crate::Endian).
+    #[must_use]
     pub fn new(endian: Endian) -> Self {
         Self {
             endian,
@@ -29,28 +28,34 @@ impl ReadOptions {
         }
     }
 
-    /// Returns the given ReadOptions but with the endian replaced
-    pub fn with_endian(self, endian: Endian) -> Self {
-        Self { endian, ..self }
-    }
-
     /// The [byte order](crate::Endian) to use when reading data.
     ///
     /// Note that if a derived type uses one of the
     /// [byte order directives](crate::docs::attribute#byte-order), this option
     /// will be overridden by the directive.
+    #[must_use]
     pub fn endian(&self) -> Endian {
         self.endian
     }
 
-    /// Returns the given ReadOptions but with the offset replaced
-    pub fn with_offset(self, offset: u64) -> Self {
-        Self { offset, ..self }
-    }
-
     /// An absolute offset added to the [`FilePtr::ptr`](crate::FilePtr::ptr)
     /// offset before reading the pointed-to value.
+    #[must_use]
     pub fn offset(&self) -> u64 {
         self.offset
+    }
+
+    /// Creates a copy of this `ReadOptions` using the given
+    /// [endianness](crate::Endian).
+    #[must_use]
+    pub fn with_endian(self, endian: Endian) -> Self {
+        Self { endian, ..self }
+    }
+
+    /// Creates a copy of this `ReadOptions` using the given
+    /// [offset](crate::docs::attribute#offset).
+    #[must_use]
+    pub fn with_offset(self, offset: u64) -> Self {
+        Self { offset, ..self }
     }
 }

--- a/binrw/src/binwrite/impls.rs
+++ b/binrw/src/binwrite/impls.rs
@@ -1,16 +1,16 @@
-use core::any::Any;
-use core::marker::PhantomData;
-use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
-    NonZeroU32, NonZeroU64, NonZeroU8,
+use crate::{
+    io::{Seek, Write},
+    BinResult, BinWrite, Endian, WriteOptions,
 };
-
-use crate::alloc::boxed::Box;
-use crate::alloc::vec::Vec;
-use crate::io::{Seek, Write};
-use crate::{BinResult, BinWrite, Endian, WriteOptions};
-
-// ============================= nums =============================
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+    any::Any,
+    marker::PhantomData,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+        NonZeroU32, NonZeroU64, NonZeroU8,
+    },
+};
 
 macro_rules! binwrite_num_impl {
     ($($type_name:ty),*$(,)?) => {
@@ -75,10 +75,6 @@ binwrite_nonzero_num_impl!(
     NonZeroI128 => i128,
 );
 
-// =========================== end nums ===========================
-
-// =========================== array/vec ===========================
-
 impl<T: BinWrite + 'static, const N: usize> BinWrite for [T; N] {
     type Args = T::Args;
 
@@ -139,10 +135,6 @@ impl<T: BinWrite + 'static> BinWrite for Vec<T> {
         Ok(())
     }
 }
-
-// ========================= end array/vec =========================
-
-// ========================= std types =========================
 
 impl<T: BinWrite + ?Sized> BinWrite for &T {
     type Args = T::Args;
@@ -205,10 +197,6 @@ impl<T: BinWrite> BinWrite for PhantomData<T> {
     }
 }
 
-// ======================= end std types =======================
-
-// =========================== tuples ===========================
-
 impl BinWrite for () {
     type Args = ();
 
@@ -259,5 +247,3 @@ binwrite_tuple_impl!(
     b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, b20, b21,
     b22, b23, b24, b25, b26, b27, b28, b29, b30, b31, b32
 );
-
-// ========================= end tuples =========================

--- a/binrw/src/builder_types.rs
+++ b/binrw/src/builder_types.rs
@@ -20,11 +20,13 @@ impl SatisfiedOrOptional for Optional {}
 
 #[doc(hidden)]
 #[cfg_attr(coverage_nightly, no_coverage)]
+#[must_use]
 pub fn passthrough_helper<T>(_a: PhantomData<T>) -> T {
     panic!("This is a type system hack and should never be called!");
 }
 
 #[doc(hidden)]
+#[must_use]
 pub fn builder_helper<T: BinrwNamedArgs>(_: PhantomData<T>) -> T::Builder {
     <T as BinrwNamedArgs>::builder()
 }

--- a/binrw/src/docs.rs
+++ b/binrw/src/docs.rs
@@ -1,11 +1,9 @@
 //! Additional long-form documentation and reference material.
 
-#[cfg(all(doc, not(feature = "std")))]
-extern crate std;
-#[cfg(all(doc, not(feature = "std")))]
-use alloc::vec::Vec;
-
 #[doc = include_str!("../doc/attribute.md")]
 pub mod attribute {}
 #[doc = include_str!("../doc/performance.md")]
 pub mod performance {}
+
+#[cfg(all(doc, not(feature = "std")))]
+use alloc::vec::Vec;

--- a/binrw/src/endian.rs
+++ b/binrw/src/endian.rs
@@ -1,7 +1,7 @@
 //! Type definitions for byte order handling.
 
-use crate::alloc::boxed::Box;
 use crate::BinResult;
+use alloc::boxed::Box;
 
 /// Defines the order of bytes in a multi-byte type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -36,8 +36,14 @@ const BOM: u16 = 0xFEFF;
 const REVERSE_BOM: u16 = 0xFFFE;
 
 impl Endian {
-    /// Converts from a UTF-16 BOM (either `[0xFF, 0xFE]` or `[0xFE, 0xFF]`) into the endian it
-    /// represents
+    /// Converts a byte array containing a UTF-16 [byte order mark] into an
+    /// `Endian` value.
+    ///
+    /// [byte order mark]: https://en.wikipedia.org/wiki/Byte_order_mark
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input does not contain a byte order mark.
     pub fn from_utf16_bom_bytes(bom: [u8; 2]) -> BinResult<Self> {
         match u16::from_le_bytes(bom) {
             BOM => Ok(Self::Little),
@@ -49,7 +55,9 @@ impl Endian {
         }
     }
 
-    /// Converts endian to a UTF-16 BOM representing the given endian
+    /// Converts an `Endian` value into an array containing a UTF-16
+    /// [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark).
+    #[must_use]
     pub fn into_utf16_bom_bytes(self) -> [u8; 2] {
         match self {
             Self::Little => u16::to_le_bytes(BOM),

--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # use binrw::{prelude::*, io::Cursor, FilePtr};
 /// #
 /// #[derive(BinRead)]
@@ -158,6 +158,10 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// [`parse_with`](crate::docs::attribute#custom-parserswriters) directive that reads
     /// and then immediately finalizes a [`FilePtr`], returning the pointed-to
     /// value as the result.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     pub fn parse<R, Args>(reader: &mut R, options: &ReadOptions, args: Args) -> BinResult<T>
     where
         R: Read + Seek,
@@ -174,6 +178,10 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// [`parse_with`](crate::docs::attribute#custom-parserswriters) directive that reads and then
     /// immediately finalizes a [`FilePtr`] using the specified parser, returning the pointed-to
     /// value as the result.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     pub fn parse_with<R, F, Args>(parser: F) -> impl Fn(&mut R, &ReadOptions, Args) -> BinResult<T>
     where
         R: Read + Seek,
@@ -190,6 +198,10 @@ impl<Ptr: BinRead<Args = ()> + IntoSeekFrom, T> FilePtr<Ptr, T> {
     /// [`parse_with`](crate::docs::attribute#custom-parserswriters) directive that reads and then
     /// immediately finalizes a [`FilePtr`] using the specified parser, returning the [`FilePtr`]
     /// as the result.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     pub fn with<R, F, Args>(parser: F) -> impl Fn(&mut R, &ReadOptions, Args) -> BinResult<Self>
     where
         R: Read + Seek,
@@ -278,8 +290,9 @@ impl<Ptr: IntoSeekFrom, BR: BinRead> Deref for FilePtr<Ptr, BR> {
     }
 }
 
-/// ## Panics
-/// Will panic if the FilePtr has not been read yet using [`BinRead::after_parse`](BinRead::after_parse)
+/// # Panics
+/// Will panic if the `FilePtr` has not been read yet using
+/// [`BinRead::after_parse`](BinRead::after_parse)
 impl<Ptr: IntoSeekFrom, BR: BinRead> DerefMut for FilePtr<Ptr, BR> {
     fn deref_mut(&mut self) -> &mut BR {
         match self.value.as_mut() {
@@ -311,6 +324,6 @@ where
     BR: BinRead + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.deref() == other.deref()
+        **self == **other
     }
 }

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -4,8 +4,6 @@ use crate::{
     io::{self, Read, Seek},
     BinRead, BinResult, Error, ReadOptions,
 };
-
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::iter::repeat_with;
 
@@ -43,11 +41,11 @@ where
     until_with(cond, read)
 }
 
-/// Do the same as [until](binrw::helpers::until) with a custom parsing function for the inner type.
+/// Do the same as [`until`] with a custom parsing function for the inner type.
 ///
 /// # Examples
 ///
-/// This example shows how to read lists of two elements until a condition is met using [until_with](binrw::helpers::until_with) coupled with [count](binrw::helpers::count).
+/// This example shows how to read lists of two elements until a condition is met using [`until_with`] coupled with [`count`].
 /// ```
 /// # use binrw::{BinRead, helpers::{until, until_with, count}, io::Cursor, BinReaderExt};
 /// # use std::collections::VecDeque;
@@ -77,13 +75,13 @@ where
         let mut last_error = false;
         repeat_with(|| read(reader, ro, args.clone()))
             .take_while(|result| {
-                let cont = last_cond && !last_error; //keep the first error we get
+                let take = last_cond && !last_error; //keep the first error we get
                 if let Ok(val) = result {
                     last_cond = !cond(val);
                 } else {
                     last_error = true;
                 }
-                cont
+                take
             })
             .collect()
     }
@@ -123,11 +121,11 @@ where
     until_exclusive_with(cond, read)
 }
 
-/// Do the same as [until_exclusive](binrw::helpers::until_exclusive) with a custom parsing function for the inner type.
+/// Do the same as [`until_exclusive`] with a custom parsing function for the inner type.
 ///
 /// # Examples
 ///
-/// This example shows how to read lists of two elements until a condition is met using [until_exclusive_with](binrw::helpers::until_exclusive_with) coupled with [count](binrw::helpers::count).
+/// This example shows how to read lists of two elements until a condition is met using [`until_exclusive_with`] coupled with [`count`].
 /// ```
 /// # use binrw::{BinRead, helpers::{until_exclusive, until_exclusive_with, count}, io::Cursor, BinReaderExt};
 /// # use std::collections::VecDeque;
@@ -170,6 +168,10 @@ where
 
 /// Read items until the end of the file is hit.
 ///
+/// # Errors
+///
+/// If reading fails, an [`Error`](crate::Error) variant will be returned.
+///
 /// # Examples
 ///
 /// ```
@@ -203,11 +205,11 @@ where
     until_eof_with(read)(reader, ro, args)
 }
 
-/// Do the same as [until_eof](binrw::helpers::until_eof) with a custom parsing function for the inner type.
+/// Do the same as [`until_eof`] with a custom parsing function for the inner type.
 ///
 /// # Examples
 ///
-/// This example shows how to read lists of two elements until the end of file using [until_eof_with](binrw::helpers::until_eof_with) coupled with [count](binrw::helpers::count).
+/// This example shows how to read lists of two elements until the end of file using [`until_eof_with`] coupled with [`count`].
 /// ```
 /// # use binrw::{BinRead, helpers::{until_eof, until_eof_with, count}, io::Cursor, BinReaderExt};
 /// # use std::collections::VecDeque;
@@ -302,11 +304,11 @@ where
     }
 }
 
-/// Do the same as [count](binrw::helpers::count) with a custom parsing function for the inner type.
+/// Do the same as [`count`] with a custom parsing function for the inner type.
 ///
 /// # Examples
 ///
-/// This example shows how to read `len` lists of two elements using [count_with](binrw::helpers::count_with) coupled with [count](binrw::helpers::count).
+/// This example shows how to read `len` lists of two elements using [`count_with`] coupled with [`count`].
 /// ```
 /// # use binrw::{BinRead, helpers::count, helpers::count_with, io::Cursor, BinReaderExt};
 /// # use std::collections::VecDeque;

--- a/binrw/src/io/mod.rs
+++ b/binrw/src/io/mod.rs
@@ -1,17 +1,16 @@
 //! Traits, helpers, and type definitions for core I/O functionality.
 //!
 //! By default, this module simply re-exports the parts of [`std::io`] that are
-//! used by binrw. In no_std environments, a compatible subset API is exposed
+//! used by binrw. In `no_std` environments, a compatible subset API is exposed
 //! instead.
 
 #[cfg(feature = "std")]
 mod bufreader;
-pub mod prelude;
-mod seek;
-#[cfg(all(doc, not(feature = "std")))]
-extern crate std;
 #[cfg(not(feature = "std"))]
 mod no_std;
+pub mod prelude;
+mod seek;
+
 #[cfg(feature = "std")]
 pub use bufreader::BufReader;
 #[cfg(all(doc, not(feature = "std")))]

--- a/binrw/src/io/no_std/cursor.rs
+++ b/binrw/src/io/no_std/cursor.rs
@@ -1,5 +1,5 @@
 use super::{Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
-use crate::alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::cmp;
 
 /// A `Cursor` wraps an in-memory buffer and provides it with a

--- a/binrw/src/io/no_std/error.rs
+++ b/binrw/src/io/no_std/error.rs
@@ -77,6 +77,7 @@ pub enum ErrorKind {
 impl Error {
     /// Creates a new I/O error from a known kind of error as well as an
     /// arbitrary error payload.
+    #[must_use]
     pub fn new<A>(kind: ErrorKind, _: A) -> Self {
         Self {
             repr: Repr::Simple(kind),
@@ -84,6 +85,7 @@ impl Error {
     }
 
     /// Returns the corresponding [`ErrorKind`] for this error.
+    #[must_use]
     pub fn kind(&self) -> ErrorKind {
         match self.repr {
             Repr::Simple(kind) => kind,

--- a/binrw/src/io/no_std/mod.rs
+++ b/binrw/src/io/no_std/mod.rs
@@ -1,5 +1,6 @@
-#[cfg(doc)]
-extern crate std;
+// Lint: This code is mostly taken from `std::io` which does not use the
+// pedantic lint group.
+#![allow(clippy::pedantic)]
 
 mod cursor;
 mod error;

--- a/binrw/src/io/seek.rs
+++ b/binrw/src/io/seek.rs
@@ -1,8 +1,6 @@
 //! Wrapper type that provides a fake [`Seek`](crate::io::Seek) implementation.
 
 use super::{Error, ErrorKind, SeekFrom};
-
-#[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
 /// A wrapper that provides a limited implementation of

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -1,32 +1,28 @@
 #![doc = include_str!("../doc/index.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(coverage_nightly, feature(no_coverage))]
-#![warn(rust_2018_idioms)]
+#![warn(clippy::pedantic)]
 #![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+// Lint: This is not beneficial for code organisation.
+#![allow(clippy::module_name_repetitions)]
 
+extern crate alloc;
 // binrw_derive expects to be able to access items in binrw via
 // `::binrw::<whatever>`. Normally, this would fail in this crate
 // because binrw knows of no crate called "binrw".
 // This causes binrw to associate *itself* as binrw,
 // meaning it makes access via ::binrw work.
-#[allow(unused_extern_crates)]
 extern crate self as binrw;
-
-#[doc(hidden)]
-#[cfg(feature = "std")]
-pub use std as alloc;
-
-#[doc(hidden)]
-#[cfg(not(feature = "std"))]
-pub extern crate alloc;
-
 #[cfg(all(doc, not(feature = "std")))]
-use alloc::vec::Vec;
+extern crate std;
 
 #[doc(hidden)]
 #[path = "private.rs"]
 pub mod __private;
-
+mod binread;
+mod binwrite;
+mod builder_types;
 pub mod docs;
 pub mod endian;
 pub mod error;
@@ -35,15 +31,19 @@ pub mod file_ptr;
 pub mod has_magic;
 pub mod helpers;
 pub mod io;
-
 #[doc(hidden)]
 pub mod pos_value;
 pub mod punctuated;
 #[doc(hidden)]
 pub mod strings;
 
+#[cfg(all(doc, not(feature = "std")))]
+use alloc::vec::Vec;
 #[doc(inline)]
 pub use {
+    binread::*,
+    binwrite::*,
+    builder_types::*,
     endian::Endian,
     error::Error,
     file_ptr::{FilePtr, FilePtr128, FilePtr16, FilePtr32, FilePtr64, FilePtr8},
@@ -67,30 +67,26 @@ pub use binrw_derive::binread;
 /// The derive macro for [`BinWrite`].
 pub use binrw_derive::BinWrite;
 
-/// The attribute version of the derive macro for [`BinWrite`].
+/// The attribute version of the derive macro for [`BinWrite`]. Use this instead
+/// of `#[derive(BinWrite)]` to enable [temporary variables](docs::attribute#temp).
+///
+/// Note that `#[binwrite]` should be placed above other `#[derive(..)]`
+/// directives to avoid issues where other derived methods (e.g. from
+/// `#[derive(Debug)]`) try to access fields that are removed by `#[binwrite]`.
 pub use binrw_derive::binwrite;
 
 /// The attribute version of the derive macro for both [`BinRead`] and [`BinWrite`]. Use
 /// instead of `#[derive(BinRead, BinWrite)]` to enable [temporary variables](docs::attribute#temp).
 ///
-/// Note that `#[binrw]` should be placed above other `#[derive(..)]` directives to avoid
-/// issues where other derived methods (e.g. from `#[derive(Debug)]`) try to access fields that are
-/// removed by `#[binrw]`.
+/// Note that `#[binrw]` should be placed above other `#[derive(..)]` directives
+/// to avoid issues where other derived methods (e.g. from `#[derive(Debug)]`)
+/// try to access fields that are removed by `#[binrw]`.
 pub use binrw_derive::binrw;
 
 pub use binrw_derive::BinrwNamedArgs;
 
-/// A specialized [`Result`] type for BinRead operations.
+/// A specialized [`Result`] type for binrw operations.
 pub type BinResult<T> = core::result::Result<T, Error>;
-
-mod binread;
-pub use binread::*;
-
-mod binwrite;
-pub use binwrite::*;
-
-mod builder_types;
-pub use builder_types::*;
 
 pub mod prelude {
     //! The binrw prelude.

--- a/binrw/src/punctuated.rs
+++ b/binrw/src/punctuated.rs
@@ -1,8 +1,9 @@
 //! Type definitions for wrappers which parse interleaved data.
 
-use crate::io::{Read, Seek};
-use crate::{BinRead, BinResult, ReadOptions, VecArgs};
-#[cfg(not(feature = "std"))]
+use crate::{
+    io::{Read, Seek},
+    BinRead, BinResult, ReadOptions, VecArgs,
+};
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -21,8 +22,8 @@ use core::fmt;
 ///
 /// # Examples
 ///
-/// ```rust
-/// # use binrw::{*, io::*};
+/// ```
+/// # use binrw::{prelude::*, io::Cursor};
 /// use binrw::punctuated::Punctuated;
 ///
 /// #[derive(BinRead)]
@@ -51,10 +52,14 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     ///
     /// Requires a count to be passed via `#[br(count)]`.
     ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
+    ///
     /// # Example
     ///
-    /// ```rust
-    /// # use binrw::{*, io::*};
+    /// ```
+    /// # use binrw::{prelude::*, io::Cursor};
     /// use binrw::punctuated::Punctuated;
     ///
     /// #[derive(BinRead)]
@@ -69,6 +74,8 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// # assert_eq!(*y.x, vec![3, 2, 1]);
     /// # assert_eq!(y.x.separators, vec![0, 1]);
     /// ```
+    // Lint: Non-consumed argument is required to match the API.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn separated<R: Read + Seek>(
         reader: &mut R,
         options: &ReadOptions,
@@ -91,6 +98,12 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// a trailing `P`.
     ///
     /// Requires a count to be passed via `#[br(count)]`.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
+    // Lint: Non-consumed argument is required to match the API.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn separated_trailing<R: Read + Seek>(
         reader: &mut R,
         options: &ReadOptions,
@@ -115,6 +128,7 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// memory and then discarding it.
     ///
     /// [`pad_after`]: crate::docs::attribute#padding-and-alignment
+    #[must_use]
     pub fn into_values(self) -> Vec<T> {
         self.data
     }

--- a/binrw/src/strings.rs
+++ b/binrw/src/strings.rs
@@ -5,10 +5,7 @@ use crate::{
     io::{Read, Seek, Write},
     BinRead, BinResult, BinWrite, ReadOptions,
 };
-
-#[cfg(not(feature = "std"))]
 use alloc::{string::String, vec, vec::Vec};
-
 use core::fmt::{self, Write as _};
 
 /// A null-terminated 8-bit string.
@@ -115,14 +112,14 @@ impl core::ops::DerefMut for NullString {
 impl fmt::Debug for NullString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "NullString(\"")?;
-        display_utf8(&self.0, f, |input| input.escape_debug())?;
+        display_utf8(&self.0, f, str::escape_debug)?;
         write!(f, "\")")
     }
 }
 
 impl fmt::Display for NullString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        display_utf8(&self.0, f, |input| input.chars())
+        display_utf8(&self.0, f, str::chars)
     }
 }
 
@@ -243,7 +240,7 @@ impl fmt::Display for NullWideString {
 impl fmt::Debug for NullWideString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "NullWideString(\"")?;
-        display_utf16(&self.0, f, |input| input.escape_debug())?;
+        display_utf16(&self.0, f, char::escape_debug)?;
         write!(f, "\")")
     }
 }
@@ -277,7 +274,7 @@ fn display_utf8<'a, Transformer: Fn(&'a str) -> O, O: Iterator<Item = char> + 'a
                 f.write_char(char::REPLACEMENT_CHARACTER)?;
 
                 if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..]
+                    input = &after_valid[invalid_sequence_length..];
                 } else {
                     break;
                 }

--- a/binrw/tests/pos_value.rs
+++ b/binrw/tests/pos_value.rs
@@ -1,6 +1,5 @@
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-#[cfg(not(feature = "std"))]
+
 use alloc::format;
 use binrw::{io::Cursor, BinRead, BinReaderExt, PosValue};
 

--- a/binrw/tests/punctuated.rs
+++ b/binrw/tests/punctuated.rs
@@ -1,6 +1,5 @@
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-#[cfg(not(feature = "std"))]
+
 use alloc::format;
 use binrw::{io::Cursor, punctuated::Punctuated, BinRead, BinReaderExt};
 

--- a/binrw_derive/build.rs
+++ b/binrw_derive/build.rs
@@ -1,7 +1,3 @@
-use std::env;
-use std::process::Command;
-use std::str;
-
 fn main() {
     if is_nightly().unwrap_or(false) {
         println!("cargo:rustc-cfg=nightly");
@@ -9,9 +5,12 @@ fn main() {
 }
 
 fn is_nightly() -> Option<bool> {
-    let rustc = env::var_os("RUSTC")?;
-    let output = Command::new(rustc).arg("--version").output().ok()?;
-    let version = str::from_utf8(&output.stdout).ok()?;
+    let rustc = std::env::var_os("RUSTC")?;
+    let output = std::process::Command::new(rustc)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let version = core::str::from_utf8(&output.stdout).ok()?;
     let nightly = version.contains("nightly") || version.contains("dev");
 
     Some(nightly)

--- a/binrw_derive/src/backtrace/mod.rs
+++ b/binrw_derive/src/backtrace/mod.rs
@@ -1,15 +1,11 @@
-#![allow(clippy::non_ascii_literal)]
-use std::fmt::{self, Display, Formatter};
+mod syntax_highlighting;
 
+use crate::parser::StructField;
+use core::fmt::{self, Display, Formatter};
 use owo_colors::OwoColorize;
 use proc_macro2::Span;
 use syn::spanned::Spanned;
-
 use syntax_highlighting::{conditional_bold, CondOwo, SyntaxInfo};
-
-use crate::parser::StructField;
-
-mod syntax_highlighting;
 
 pub(crate) struct BacktraceFrame {
     span: Span,
@@ -120,7 +116,7 @@ impl BacktraceFrame {
                 .iter()
                 .skip(1)
                 .map(|x| x.0.start)
-                .chain(std::iter::once(start_col + line.len()));
+                .chain(core::iter::once(start_col + line.len()));
 
             if let Some((first_range, _)) = line_highlights.highlights.get(0) {
                 let component = &line[..first_range.start - start_col];

--- a/binrw_derive/src/codegen/mod.rs
+++ b/binrw_derive/src/codegen/mod.rs
@@ -1,8 +1,7 @@
-#[macro_use]
-pub(crate) mod sanitization;
 mod has_magic;
 mod imports;
 mod read_options;
+pub(crate) mod sanitization;
 pub(crate) mod typed_builder;
 mod types;
 mod write_options;
@@ -10,8 +9,10 @@ mod write_options;
 use crate::parser::{Input, ParseResult};
 use proc_macro2::TokenStream;
 use quote::quote;
-#[allow(clippy::wildcard_imports)]
-use sanitization::*;
+use sanitization::{
+    ARGS, BINREAD_TRAIT, BINWRITE_TRAIT, BIN_RESULT, OPT, READER, READ_OPTIONS, READ_TRAIT,
+    SEEK_TRAIT, WRITER, WRITE_OPTIONS, WRITE_TRAIT,
+};
 
 pub(crate) fn generate_binread_impl(
     derive_input: &syn::DeriveInput,

--- a/binrw_derive/src/codegen/read_options.rs
+++ b/binrw_derive/src/codegen/read_options.rs
@@ -2,9 +2,13 @@ mod r#enum;
 mod map;
 mod r#struct;
 
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::{Assert, AssertionError, CondEndian, Endian, Input, Magic, Map};
+use crate::{
+    codegen::sanitization::{
+        IdentStr, ARGS, ASSERT, ASSERT_ERROR_FN, ASSERT_MAGIC, BIN_ERROR, ENDIAN_ENUM, OPT, POS,
+        READER, SEEK_FROM, SEEK_TRAIT, TEMP,
+    },
+    parser::{Assert, AssertionError, CondEndian, Endian, Input, Magic, Map},
+};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::Ident;

--- a/binrw_derive/src/codegen/read_options/enum.rs
+++ b/binrw_derive/src/codegen/read_options/enum.rs
@@ -3,16 +3,18 @@ use super::{
     r#struct::{generate_unit_struct, StructGenerator},
     PreludeGenerator,
 };
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::{Enum, EnumErrorMode, EnumVariant, Input, UnitEnumField, UnitOnlyEnum};
-
+use crate::{
+    codegen::sanitization::{
+        BACKTRACE_FRAME, BIN_ERROR, ERROR_BASKET, OPT, POS, READER, READ_METHOD, SEEK_FROM,
+        SEEK_TRAIT, TEMP, WITH_CONTEXT,
+    },
+    parser::{Enum, EnumErrorMode, EnumVariant, Input, UnitEnumField, UnitOnlyEnum},
+};
+use core::cmp::Ordering;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Ident;
-
-use std::cmp::Ordering;
 use std::collections::HashMap;
+use syn::Ident;
 
 pub(super) fn generate_unit_enum(
     input: &Input,
@@ -53,9 +55,10 @@ fn generate_unit_enum_repr(repr: &TokenStream, variants: &[UnitEnumField]) -> To
                 #BIN_ERROR::NoVariantMatch {
                     pos: #POS,
                 },
-                #BACKTRACE_FRAME::OwnedMessage(
-                    ::binrw::alloc::format!("Unexpected value for enum: {:?}", #TEMP)
-                )
+                #BACKTRACE_FRAME::OwnedMessage({
+                    extern crate alloc;
+                    alloc::format!("Unexpected value for enum: {:?}", #TEMP)
+                })
             ))
         }
     }

--- a/binrw_derive/src/codegen/read_options/map.rs
+++ b/binrw_derive/src/codegen/read_options/map.rs
@@ -1,5 +1,4 @@
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
+use crate::codegen::sanitization::{ARGS, OPT, POS, READER, READ_METHOD};
 use crate::parser::Input;
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -99,7 +99,7 @@ pub(crate) fn make_ident(ident: &Ident, kind: &str) -> Ident {
 /// A string wrapper that converts the str to a $path `TokenStream`, allowing
 /// for constant-time idents that can be shared across threads
 #[derive(Clone, Copy)]
-pub struct IdentStr(&'static str);
+pub(crate) struct IdentStr(&'static str);
 
 impl IdentStr {
     #[cfg_attr(coverage_nightly, no_coverage)] // const-only function

--- a/binrw_derive/src/codegen/typed_builder.rs
+++ b/binrw_derive/src/codegen/typed_builder.rs
@@ -1,10 +1,10 @@
+use crate::{
+    codegen::sanitization::{BINRW_NAMED_ARGS, NEEDED, OPTIONAL, SATISFIED, SATISFIED_OR_OPTIONAL},
+    parser::IdentTypeMaybeDefault,
+};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{GenericArgument, GenericParam, Ident, Type, Visibility};
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::IdentTypeMaybeDefault;
 
 pub(crate) enum BuilderFieldKind {
     Required,

--- a/binrw_derive/src/codegen/types.rs
+++ b/binrw_derive/src/codegen/types.rs
@@ -1,9 +1,7 @@
+use crate::codegen::sanitization::ENDIAN_ENUM;
+use crate::parser::Endian;
 use proc_macro2::TokenStream;
 use quote::quote;
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::Endian;
 
 impl Endian {
     pub(crate) fn as_binrw_endian(self) -> TokenStream {

--- a/binrw_derive/src/codegen/write_options.rs
+++ b/binrw_derive/src/codegen/write_options.rs
@@ -1,18 +1,18 @@
-use crate::parser::{Assert, AssertionError, Input, Map};
-use proc_macro2::TokenStream;
-use quote::quote;
-
-mod r#struct;
-use r#struct::generate_struct;
-
+mod r#enum;
 mod prelude;
+mod r#struct;
 mod struct_field;
 
-mod r#enum;
+use crate::{
+    codegen::sanitization::{
+        IdentStr, ASSERT, ASSERT_ERROR_FN, BIN_ERROR, OPT, POS, SEEK_TRAIT, WRITER, WRITE_METHOD,
+    },
+    parser::{Assert, AssertionError, Input, Map},
+};
+use proc_macro2::TokenStream;
+use quote::quote;
 use r#enum::{generate_data_enum, generate_unit_enum};
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
+use r#struct::generate_struct;
 
 pub(crate) fn generate(input: &Input, derive_input: &syn::DeriveInput) -> TokenStream {
     let name = Some(&derive_input.ident);

--- a/binrw_derive/src/codegen/write_options/enum.rs
+++ b/binrw_derive/src/codegen/write_options/enum.rs
@@ -1,11 +1,10 @@
-use crate::parser::{Enum, EnumVariant, Input, UnitEnumField, UnitOnlyEnum};
+use super::{prelude::PreludeGenerator, r#struct::StructGenerator};
+use crate::{
+    codegen::sanitization::{OPT, WRITER, WRITE_METHOD},
+    parser::{Enum, EnumVariant, Input, UnitEnumField, UnitOnlyEnum},
+};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-
-use super::{prelude::PreludeGenerator, r#struct::StructGenerator};
 
 pub(crate) fn generate_unit_enum(
     input: &Input,

--- a/binrw_derive/src/codegen/write_options/prelude.rs
+++ b/binrw_derive/src/codegen/write_options/prelude.rs
@@ -1,9 +1,9 @@
+use crate::{
+    codegen::sanitization::{ARGS, OPT, WRITER, WRITE_METHOD},
+    parser::{CondEndian, Input, Magic},
+};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::{CondEndian, Input, Magic};
 
 pub(crate) struct PreludeGenerator<'a> {
     out: TokenStream,

--- a/binrw_derive/src/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/codegen/write_options/struct_field.rs
@@ -1,12 +1,16 @@
-use std::ops::Not;
-
+use crate::{
+    codegen::sanitization::{
+        make_ident, ARGS_MACRO, BEFORE_POS, BINWRITE_TRAIT, OPT, SAVED_POSITION, SEEK_FROM,
+        SEEK_TRAIT, WRITER, WRITE_FN_MAP_OUTPUT_TYPE_HINT, WRITE_FN_TRY_MAP_OUTPUT_TYPE_HINT,
+        WRITE_FN_TYPE_HINT, WRITE_FUNCTION, WRITE_MAP_ARGS_TYPE_HINT, WRITE_MAP_INPUT_TYPE_HINT,
+        WRITE_METHOD, WRITE_TRY_MAP_ARGS_TYPE_HINT, WRITE_WITH_ARGS_TYPE_HINT, WRITE_ZEROES,
+    },
+    parser::{CondEndian, FieldMode, Map, PassedArgs, StructField},
+};
+use core::ops::Not;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
-
-#[allow(clippy::wildcard_imports)]
-use crate::codegen::sanitization::*;
-use crate::parser::{CondEndian, FieldMode, Map, PassedArgs, StructField};
 
 pub(crate) fn write_field(field: &StructField) -> TokenStream {
     StructFieldGenerator::new(field)

--- a/binrw_derive/src/lib.rs
+++ b/binrw_derive/src/lib.rs
@@ -1,10 +1,5 @@
 #![warn(clippy::pedantic)]
 #![warn(rust_2018_idioms)]
-#![allow(
-    clippy::expl_impl_clone_on_copy,
-    clippy::large_enum_variant,
-    clippy::redundant_closure_for_method_calls
-)]
 #![cfg_attr(all(nightly, not(coverage)), feature(proc_macro_span))]
 #![cfg_attr(all(nightly, coverage), feature(no_coverage))]
 

--- a/binrw_derive/src/named_args/mod.rs
+++ b/binrw_derive/src/named_args/mod.rs
@@ -109,8 +109,7 @@ mod kw {
 #[test]
 fn derive_named_args_code_coverage_for_tool() {
     use runtime_macros_derive::emulate_derive_expansion_fallible;
-    use std::fs;
-    let file = fs::File::open("../binrw/tests/builder.rs").unwrap();
+    let file = std::fs::File::open("../binrw/tests/builder.rs").unwrap();
     emulate_derive_expansion_fallible(file, "BinrwNamedArgs", |input| derive_from_attribute(input))
         .unwrap();
 }

--- a/binrw_derive/src/parser/field_level_attrs.rs
+++ b/binrw_derive/src/parser/field_level_attrs.rs
@@ -174,7 +174,7 @@ impl StructField {
                     list.span(),
                     format!(
                         "({},{})",
-                        list.first().map_or_else(<_>::default, |t| t.to_string()),
+                        list.first().map_or_else(<_>::default, ToString::to_string),
                         if list.len() > 1 { " ..." } else { "" }
                     ),
                 ),

--- a/binrw_derive/src/parser/mod.rs
+++ b/binrw_derive/src/parser/mod.rs
@@ -15,7 +15,7 @@ use meta_types::MetaAttrList;
 // TODO: Should export a processed type, not a meta type
 pub(crate) use meta_types::IdentTypeMaybeDefault;
 use proc_macro2::Span;
-pub(crate) use result::*;
+pub(crate) use result::ParseResult;
 use syn::token::Token;
 pub(crate) use top_level_attrs::{Enum, Input, Struct, UnitOnlyEnum};
 use try_set::TrySet;
@@ -140,10 +140,9 @@ trait KeywordToken {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use proc_macro2::TokenStream;
     use syn::DeriveInput;
-
-    use super::*;
 
     fn try_input(input: TokenStream) -> ParseResult<Input> {
         Input::from_input(

--- a/binrw_derive/src/parser/types/map.rs
+++ b/binrw_derive/src/parser/types/map.rs
@@ -2,7 +2,6 @@ use crate::parser::{attrs, KeywordToken, TrySet};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 
-#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug)]
 pub(crate) enum Map {
     None,


### PR DESCRIPTION
Also pedantically clean up other things that clippy is not even pedantic enough to complain about yet, like:

* Unnecessary and/or unexplained lint suppressions
* `rust` in code blocks
* Inconsistent import and module list ordering
* Conditional `std` imports that can just always use `alloc`
* Unnecessary `pub` visibility