### PR TITLE
README & Homepage fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # binrw
 
+[![crates](https://img.shields.io/crates/v/binrw.svg)](https://crates.io/crates/binrw)
 [![tests](https://github.com/jam1garner/binrw/actions/workflows/main.yml/badge.svg)](https://github.com/jam1garner/binrw/actions/workflows/main.yml)
 [![docs.rs](https://docs.rs/binrw/badge.svg)](https://docs.rs/binrw)
 [![codecov](https://codecov.io/gh/jam1garner/binrw/branch/master/graph/badge.svg?token=UREOWI2KAY)](https://codecov.io/gh/jam1garner/binrw) 

--- a/binrw/Cargo.toml
+++ b/binrw/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 description = "A Rust crate for helping read structs from binary data using ✨macro magic✨"
 readme = "../README.md"
 documentation = "https://docs.rs/binrw"
+homepage = "https://binrw.rs"
 
 [dependencies]
 array-init = "2.0"

--- a/binrw_derive/Cargo.toml
+++ b/binrw_derive/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 description = "Derive macro for binrw"
 repository = "https://github.com/jam1garner/binrw"
 license = "MIT"
+homepage = "https://binrw.rs"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Happy binrw user here, so here's an easy PR!

I just noticed the [new homepage is up](https://binrw.rs) (yay!) but it's not present on crates.io yet. Since we are coming up on a release, it's probably a good idea to add it now.

I also fixed another thing that was bugging me, and that there was no easy way to get back to the crates.io page from here, so I added a badge for that in as well. I put it in a separate commit, in case you don't want it or want it moved etc. For some reason, shields.io picks up on pre-release versions but oh well.

<img width="415" alt="image" src="https://user-images.githubusercontent.com/54911369/190010513-2302a211-4d09-4ade-ae89-ff34aaf61b9c.png">
