### PR TITLE
Implement a type for strings with pre-computed length

### DIFF
--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -47,7 +47,7 @@ pub use {
     file_ptr::{FilePtr, FilePtr128, FilePtr16, FilePtr32, FilePtr64, FilePtr8},
     helpers::{count, until, until_eof, until_exclusive},
     pos_value::PosValue,
-    strings::{NullString, NullWideString},
+    strings::{NullString, NullWideString, FixedLenString},
 };
 
 /// The derive macro for [`BinRead`].


### PR DESCRIPTION
I have a type that is basically the `EmbeddedString` type from the doc example, and wanted to contribute it back for other users.

I know this is basically the same as the below, but seemed useful anyway:
```rust
 #[binread]
 #[derive(Debug)]
 struct EmbeddedString {
     #[br(temp)]
     _len: u8,
     #[br(parse_with = count(_len.into()))]
     string: Vec<u8>
 }
```