### PR TITLE
Add `dbg` directive (updated)

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -79,6 +79,7 @@ Glossary of directives in binrw attributes (`#[br]`, `#[bw]`, `#[brw]`).
 | rw  | [`big`](#byte-order) | all except unit variant | Sets the byte order to big-endian.
 | rw  | [`calc`](#calculations) | field | Computes the value of a field instead of reading data.
 | r   | [`count`](#count) | field | Sets the length of a vector.
+| r   | [`dbg`](#debug) | field | Prints out the parsed value and offset to help debug
 | r   | [`default`](#ignore) | field | An alias for `ignore`.
 | r   | [`deref_now`](#postprocessing) | field | An alias for `postprocess_now`.
 | r   | [`err_context`](#backtrace) | field | Adds additional context to errors.

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -177,3 +177,18 @@ pub fn write_zeroes<W: Write>(writer: &mut W, count: u64) -> BinResult<()> {
 
     Ok(())
 }
+
+#[cfg(feature = "std")]
+pub use std::eprintln;
+
+#[cfg(not(feature = "std"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! eprintln {
+    ($($tt:tt)*) => {
+        compile_error!("dbg requires feature `std`")
+    };
+}
+
+#[cfg(not(feature = "std"))]
+pub use crate::eprintln;

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -573,3 +573,22 @@ fn tuple_calc_temp_field() {
     // compilation would fail if it weren’t due to missing a second item
     assert_eq!(result, Test(5u32));
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn debug() {
+    #[allow(dead_code)]
+    #[binread]
+    #[br(big)]
+    struct Test {
+        before: u16,
+        #[br(dbg, big)]
+        value: u32,
+    }
+
+    let _ = Test::read(&mut Cursor::new(b"\0\0\0\0\0\x04")).unwrap();
+
+    // outputs:
+    //
+    // [binrw/tests/derive/structs.rs:383 | offset 0x2] value = 0x4
+}

--- a/binrw/tests/ui/invalid_keyword_struct_field.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct_field.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
  --> $DIR/invalid_keyword_struct_field.rs:5:10
   |
 5 |     #[br(invalid_struct_field_keyword)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -4,13 +4,13 @@ error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`
 6 | #[br(invalid_keyword_struct)]
   |      ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
  --> $DIR/non_blocking_errors.rs:8:10
   |
 8 |     #[br(invalid_keyword_struct_field_a)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
   --> $DIR/non_blocking_errors.rs:10:10
    |
 10 |     #[br(invalid_keyword_struct_field_b)]

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -92,6 +92,7 @@ ident_str! {
     pub(crate) READ_FUNCTION = "__binrw_generated_read_function";
     pub(crate) WRITE_FUNCTION = "__binrw_generated_write_function";
     pub(crate) BEFORE_POS = "__binrw_generated_before_pos";
+    pub(crate) DBG_EPRINTLN = from_crate!(__private::eprintln);
 }
 
 pub(crate) fn make_ident(ident: &Ident, kind: &str) -> Ident {

--- a/binrw_derive/src/parser/attrs.rs
+++ b/binrw_derive/src/parser/attrs.rs
@@ -16,6 +16,7 @@ pub(super) type Assert = AssertLike<kw::assert>;
 pub(super) type Big = MetaVoid<kw::big>;
 pub(super) type Calc = MetaExpr<kw::calc>;
 pub(super) type Count = MetaExpr<kw::count>;
+pub(super) type Debug = MetaVoid<kw::dbg>;
 pub(super) type Default = MetaVoid<kw::default>;
 pub(super) type DerefNow = MetaVoid<kw::deref_now>;
 pub(super) type ErrContext = MetaList<kw::err_context, Expr>;

--- a/binrw_derive/src/parser/field_level_attrs.rs
+++ b/binrw_derive/src/parser/field_level_attrs.rs
@@ -58,6 +58,8 @@ attr_struct! {
         pub(crate) seek_before: Option<TokenStream>,
         #[from(RW:PadSizeTo)]
         pub(crate) pad_size_to: Option<TokenStream>,
+        #[from(RO:Debug)] // TODO is this really RO?
+        pub(crate) debug: Option<()>,
     }
 }
 
@@ -237,6 +239,7 @@ impl FromField for StructField {
             pad_size_to: <_>::default(),
             keyword_spans: <_>::default(),
             err_context: <_>::default(),
+            debug: <_>::default(),
         };
 
         let result = if options.write {

--- a/binrw_derive/src/parser/keywords.rs
+++ b/binrw_derive/src/parser/keywords.rs
@@ -20,6 +20,7 @@ define_keywords! {
     bw,
     calc,
     count,
+    dbg,
     default,
     deref_now,
     err_context,


### PR DESCRIPTION
Rebased #16 as suggested by #50

Currently I just kept it as ReadOnly but I don't see any reason why it couldn't be expanded to work with writing too. 