### PR TITLE
Remove redundant prefix from `NamedArgs` derive/trait and normalize mods

### DIFF
--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{self, Read, Seek, SeekFrom},
-    BinRead, BinResult, BinrwNamedArgs, Endian, Error, ReadOptions,
+    BinRead, BinResult, Endian, Error, NamedArgs, ReadOptions,
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::num::{
@@ -123,7 +123,7 @@ binread_nonzero_impl! {
 ///     elements: Vec<u32>,
 /// }
 /// ```
-#[derive(BinrwNamedArgs, Clone)]
+#[derive(NamedArgs, Clone)]
 pub struct VecArgs<Inner: Clone> {
     /// The number of elements to read.
     pub count: usize,

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -10,8 +10,8 @@
 
 extern crate alloc;
 // This extern crate declaration is required to use binrw_derive macros like
-// BinrwNamedArgs inside binrw because the generated code references a binrw
-// crate, but binrw is not a dependency of binrw so no crate with that name gets
+// NamedArgs inside binrw because the generated code references a binrw crate,
+// but binrw is not a dependency of binrw so no crate with that name gets
 // automatically added by cargo to the extern prelude.
 extern crate self as binrw;
 #[cfg(all(doc, not(feature = "std")))]
@@ -22,7 +22,6 @@ extern crate std;
 pub mod __private;
 mod binread;
 mod binwrite;
-mod builder_types;
 pub mod docs;
 pub mod endian;
 pub mod error;
@@ -30,6 +29,7 @@ pub mod file_ptr;
 pub mod helpers;
 pub mod io;
 pub mod meta;
+mod named_args;
 #[doc(hidden)]
 pub mod pos_value;
 pub mod punctuated;
@@ -42,11 +42,11 @@ use alloc::vec::Vec;
 pub use {
     binread::*,
     binwrite::*,
-    builder_types::*,
     endian::Endian,
     error::Error,
     file_ptr::{FilePtr, FilePtr128, FilePtr16, FilePtr32, FilePtr64, FilePtr8},
     helpers::{count, until, until_eof, until_exclusive},
+    named_args::*,
     pos_value::PosValue,
     strings::{NullString, NullWideString},
 };
@@ -84,8 +84,8 @@ pub use binrw_derive::binwrite;
 /// try to access fields that are removed by `#[binrw]`.
 pub use binrw_derive::binrw;
 
-/// The derive macro for [`BinrwNamedArgs`].
-pub use binrw_derive::BinrwNamedArgs;
+/// The derive macro for [`NamedArgs`].
+pub use binrw_derive::NamedArgs;
 
 /// A specialized [`Result`] type for binrw operations.
 pub type BinResult<T> = core::result::Result<T, Error>;

--- a/binrw/src/named_args.rs
+++ b/binrw/src/named_args.rs
@@ -5,8 +5,8 @@ use core::marker::PhantomData;
 /// A convenience macro for constructing
 /// [named arguments](crate::docs::attribute#named-arguments).
 ///
-/// This macro uses the [`builder()`](BinrwNamedArgs::builder) function of a
-/// [named arguments type](BinrwNamedArgs), and can only be used in positions
+/// This macro uses the [`builder()`](NamedArgs::builder) function of a
+/// [named arguments type](NamedArgs), and can only be used in positions
 /// where the type can be inferred by the compiler (i.e. as a function argument
 /// or an assignment to a variable with an explicit type).
 ///
@@ -57,10 +57,10 @@ macro_rules! args {
     };
 }
 
-/// The `BinrwNamedArgs` trait allows
+/// The `NamedArgs` trait allows
 /// [named arguments](crate::docs::attribute#named-arguments) objects
 /// to be constructed using a compile-time builder.
-pub trait BinrwNamedArgs {
+pub trait NamedArgs {
     /// The builder type for this type.
     type Builder;
 
@@ -95,6 +95,6 @@ pub fn passthrough_helper<T>(_a: PhantomData<T>) -> T {
 
 #[doc(hidden)]
 #[must_use]
-pub fn builder_helper<T: BinrwNamedArgs>(_: PhantomData<T>) -> T::Builder {
-    <T as BinrwNamedArgs>::builder()
+pub fn builder_helper<T: NamedArgs>(_: PhantomData<T>) -> T::Builder {
+    <T as NamedArgs>::builder()
 }

--- a/binrw/tests/named_args.rs
+++ b/binrw/tests/named_args.rs
@@ -1,9 +1,9 @@
-use binrw::BinrwNamedArgs;
+use binrw::NamedArgs;
 
 #[derive(Eq, PartialEq, Debug)]
 struct NotClone;
 
-#[derive(BinrwNamedArgs)]
+#[derive(NamedArgs)]
 struct Test<T: Clone> {
     blah: u32,
     not_copy: String,

--- a/binrw/tests/ui/args_vec_mistakes.stderr
+++ b/binrw/tests/ui/args_vec_mistakes.stderr
@@ -28,7 +28,7 @@ error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::Ve
 13 | struct Baz(#[br(args { inner: () })] Vec<u8>);
    |                 ^^^^ method cannot be called on `binrw::binread::impls::VecArgsBuilder<(), Needed, Satisfied>` due to unsatisfied trait bounds
    |
-  ::: src/builder_types.rs
+  ::: src/named_args.rs
    |
    | pub struct Needed;
    | ----------------- doesn't satisfy `Needed: SatisfiedOrOptional`
@@ -43,7 +43,7 @@ error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::Ve
 22 | struct Qux(#[br(count = 1)] Vec<Inner>);
    |                             ^^^^^^^^^^ method cannot be called on `binrw::binread::impls::VecArgsBuilder<(NoDefault,), Satisfied, Needed>` due to unsatisfied trait bounds
    |
-  ::: src/builder_types.rs
+  ::: src/named_args.rs
    |
    | pub struct Needed;
    | ----------------- doesn't satisfy `Needed: SatisfiedOrOptional`

--- a/binrw/tests/ui/named_args_unsupported_tuple_struct.rs
+++ b/binrw/tests/ui/named_args_unsupported_tuple_struct.rs
@@ -1,6 +1,6 @@
-use binrw::BinrwNamedArgs;
+use binrw::NamedArgs;
 
-#[derive(BinrwNamedArgs)]
+#[derive(NamedArgs)]
 struct Tuple(u32, String);
 
 fn main() {}

--- a/binrw/tests/ui/named_args_unsupported_type_union.rs
+++ b/binrw/tests/ui/named_args_unsupported_type_union.rs
@@ -1,6 +1,6 @@
-use binrw::BinrwNamedArgs;
+use binrw::NamedArgs;
 
-#[derive(BinrwNamedArgs)]
+#[derive(NamedArgs)]
 union Foo {
     a: i32,
 }

--- a/binrw_derive/src/codegen/imports.rs
+++ b/binrw_derive/src/codegen/imports.rs
@@ -1,5 +1,5 @@
 use crate::{
-    codegen::typed_builder::{Builder, BuilderField},
+    codegen::named_args::{Builder, BuilderField},
     parser::{IdentTypeMaybeDefault, Imports},
 };
 use proc_macro2::{Span, TokenStream};

--- a/binrw_derive/src/codegen/mod.rs
+++ b/binrw_derive/src/codegen/mod.rs
@@ -1,8 +1,8 @@
 mod imports;
 mod meta;
+pub(crate) mod named_args;
 mod read_options;
 pub(crate) mod sanitization;
-pub(crate) mod typed_builder;
 mod write_options;
 
 use crate::{

--- a/binrw_derive/src/codegen/named_args.rs
+++ b/binrw_derive/src/codegen/named_args.rs
@@ -1,5 +1,5 @@
 use crate::{
-    codegen::sanitization::{BINRW_NAMED_ARGS, NEEDED, OPTIONAL, SATISFIED, SATISFIED_OR_OPTIONAL},
+    codegen::sanitization::{NAMED_ARGS, NEEDED, OPTIONAL, SATISFIED, SATISFIED_OR_OPTIONAL},
     parser::IdentTypeMaybeDefault,
 };
 use proc_macro2::TokenStream;
@@ -100,7 +100,7 @@ impl<'a> Builder<'a> {
                 }
             }
 
-            impl< #user_bounds > #BINRW_NAMED_ARGS for #name < #user_generic_args > {
+            impl< #user_bounds > #NAMED_ARGS for #name < #user_generic_args > {
                 type Builder = #builder_name < #user_generic_args #initial_generics >;
 
                 fn builder() -> Self::Builder {

--- a/binrw_derive/src/codegen/sanitization.rs
+++ b/binrw_derive/src/codegen/sanitization.rs
@@ -60,7 +60,7 @@ ident_str! {
     pub(crate) SATISFIED = from_crate!(Satisfied);
     pub(crate) NEEDED = from_crate!(Needed);
     pub(crate) OPTIONAL = from_crate!(Optional);
-    pub(crate) BINRW_NAMED_ARGS = from_crate!(BinrwNamedArgs);
+    pub(crate) NAMED_ARGS = from_crate!(NamedArgs);
     pub(crate) ARGS_MACRO = from_crate!(args);
     pub(crate) META_ENDIAN_KIND = from_crate!(meta::EndianKind);
     pub(crate) READ_ENDIAN = from_crate!(meta::ReadEndian);

--- a/binrw_derive/src/lib.rs
+++ b/binrw_derive/src/lib.rs
@@ -67,9 +67,9 @@ pub fn binrw(attr: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(BinrwNamedArgs, attributes(named_args))]
+#[proc_macro_derive(NamedArgs, attributes(named_args))]
 #[cfg_attr(coverage_nightly, no_coverage)]
-pub fn derive_binrw_named_args(input: TokenStream) -> TokenStream {
+pub fn derive_named_args_trait(input: TokenStream) -> TokenStream {
     named_args::derive_from_attribute(parse_macro_input!(input as DeriveInput)).into()
 }
 

--- a/binrw_derive/src/named_args/mod.rs
+++ b/binrw_derive/src/named_args/mod.rs
@@ -1,4 +1,4 @@
-use crate::codegen::typed_builder::{Builder, BuilderField, BuilderFieldKind};
+use crate::codegen::named_args::{Builder, BuilderField, BuilderFieldKind};
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
@@ -98,7 +98,7 @@ mod kw {
 #[test]
 fn derive_named_args_code_coverage_for_tool() {
     use runtime_macros_derive::emulate_derive_expansion_fallible;
-    let file = std::fs::File::open("../binrw/tests/builder.rs").unwrap();
-    emulate_derive_expansion_fallible(file, "BinrwNamedArgs", |input| derive_from_attribute(input))
+    let file = std::fs::File::open("../binrw/tests/named_args.rs").unwrap();
+    emulate_derive_expansion_fallible(file, "NamedArgs", |input| derive_from_attribute(input))
         .unwrap();
 }


### PR DESCRIPTION
I don’t think this should be controversial but it is a minor breaking change that renames a public API so sending by PR.