### PR TITLE
Improve accuracy of dbg line numbering in nightly builds

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -1189,6 +1189,11 @@ The `dbg` directive prints the offset and value of a field to
 
 The type of the field being inspected must implement [`Debug`](std::fmt::Debug).
 
+Non-nightly Rust versions without support for
+[`proc_macro_span`](https://github.com/rust-lang/rust/issues/54725) will emit
+line numbers pointing to the binrw attribute on the parent struct or enum rather
+than the field.
+
 ## Examples
 
 ```
@@ -1217,9 +1222,9 @@ struct Test {
 
 // prints:
 //
-// [file.rs:1 | offset 0x2] a = 0x10
-// [file.rs:1 | offset 0x6] b = 0x40302010
-// [file.rs:10 | offset 0x2] inner = Inner {
+// [file.rs:5 | offset 0x2] a = 0x10
+// [file.rs:7 | offset 0x6] b = 0x40302010
+// [file.rs:15 | offset 0x2] inner = Inner {
 //     a: 0x10,
 //     b: 0x40302010,
 // }

--- a/binrw/tests/dbg.rs
+++ b/binrw/tests/dbg.rs
@@ -36,12 +36,14 @@ fn dbg() {
             std::str::from_utf8(&result).unwrap(),
             format!(
                 concat!(
-                    "[{file}:10 | offset 0x2] value = 0x4\n",
-                    "[{file}:10 | offset 0x6] inner = Inner(\n",
+                    "[{file}:{offset_0} | offset 0x2] value = 0x4\n",
+                    "[{file}:{offset_1} | offset 0x6] inner = Inner(\n",
                     "    0xeffed,\n",
                     ")\n"
                 ),
-                file = core::file!()
+                file = core::file!(),
+                offset_0 = if cfg!(nightly) { 15 } else { 10 },
+                offset_1 = if cfg!(nightly) { 17 } else { 10 },
             )
         );
     }

--- a/binrw_derive/Cargo.toml
+++ b/binrw_derive/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 either = "1.8"
 owo-colors = { version = "3", optional = true }
-proc-macro2 = "1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 syn = { version = "1", features = ["extra-traits", "full"] }
 
@@ -28,4 +28,4 @@ runtime-macros-derive = "0.4.0"
 
 [features]
 default = []
-verbose-backtrace = ["proc-macro2/span-locations", "owo-colors", "syn/visit"]
+verbose-backtrace = ["owo-colors", "syn/visit"]

--- a/binrw_derive/src/codegen/read_options/struct.rs
+++ b/binrw_derive/src/codegen/read_options/struct.rs
@@ -244,14 +244,20 @@ impl<'field> FieldGenerator<'field> {
         if self.field.debug.is_some() {
             let head = self.out;
             let ident = &self.field.ident;
+            let at = if ident.span().start().line == 0 {
+                quote!(::core::line!())
+            } else {
+                ident.span().start().line.to_token_stream()
+            };
+
             self.out = quote! {
                 let #SAVED_POSITION = #SEEK_TRAIT::seek(#READER, #SEEK_FROM::Current(0))?;
 
                 #head
 
                 #DBG_EPRINTLN!(
-                    "[{}:{} | offset {:#x?}] {} = {:#x?}",
-                    ::core::file!(), ::core::line!(), #SAVED_POSITION, ::core::stringify!(#ident), &#ident
+                    "[{}:{} | offset {:#x}] {} = {:#x?}",
+                    ::core::file!(), #at, #SAVED_POSITION, ::core::stringify!(#ident), &#ident
                 );
             };
         }


### PR DESCRIPTION
I don’t know if this is valuable enough or not to do right now, since it is another one of those things that needs the `proc_macro_span` `LineColumn` stuff that [no one likes](https://github.com/rust-lang/rust/issues/54725#issuecomment-647142018). Please send opinions and hot takes.