### PR TITLE
Enable borrowing within Args using GATs

### DIFF
--- a/binrw/doc/index.md
+++ b/binrw/doc/index.md
@@ -150,9 +150,10 @@ using the `#[br]`, `#[bw]`, and `#[brw]` attributes:
 ```
 # use binrw::{prelude::*, io::Cursor, NullString};
 #
-#[derive(BinRead)]
-#[br(big, magic = b"DOG", assert(name.len() != 0))]
+#[binrw]
+#[brw(big, magic = b"DOG", assert(name.len() != 0))]
 struct Dog {
+    #[bw(try_calc(u8::try_from(bone_piles.len())))]
     bone_pile_count: u8,
 
     #[br(count = bone_pile_count)]

--- a/binrw/src/binwrite/mod.rs
+++ b/binrw/src/binwrite/mod.rs
@@ -44,7 +44,7 @@ pub trait BinWrite {
     /// [`write()`]: Self::write
     /// [`write_args()`]: Self::write_args
     /// [`write_options()`]: Self::write_options
-    type Args: Clone;
+    type Args<'a>;
 
     /// Write `Self` to the writer using default arguments.
     ///
@@ -55,7 +55,7 @@ pub trait BinWrite {
     fn write<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
     where
         Self: crate::meta::WriteEndian,
-        Self::Args: Required,
+        for<'a> Self::Args<'a>: Required,
     {
         self.write_args(writer, Self::Args::args())
     }
@@ -68,7 +68,7 @@ pub trait BinWrite {
     #[inline]
     fn write_be<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
     where
-        Self::Args: Required,
+        for<'a> Self::Args<'a>: Required,
     {
         self.write_be_args(writer, Self::Args::args())
     }
@@ -81,7 +81,7 @@ pub trait BinWrite {
     #[inline]
     fn write_le<W: Write + Seek>(&self, writer: &mut W) -> BinResult<()>
     where
-        Self::Args: Required,
+        for<'a> Self::Args<'a>: Required,
     {
         self.write_le_args(writer, Self::Args::args())
     }
@@ -92,7 +92,7 @@ pub trait BinWrite {
     ///
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
     #[inline]
-    fn write_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args) -> BinResult<()>
+    fn write_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args<'_>) -> BinResult<()>
     where
         Self: crate::meta::WriteEndian,
     {
@@ -106,7 +106,11 @@ pub trait BinWrite {
     ///
     /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     #[inline]
-    fn write_be_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args) -> BinResult<()> {
+    fn write_be_args<W: Write + Seek>(
+        &self,
+        writer: &mut W,
+        args: Self::Args<'_>,
+    ) -> BinResult<()> {
         self.write_options(writer, Endian::Big, args)
     }
 
@@ -117,7 +121,11 @@ pub trait BinWrite {
     ///
     /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     #[inline]
-    fn write_le_args<W: Write + Seek>(&self, writer: &mut W, args: Self::Args) -> BinResult<()> {
+    fn write_le_args<W: Write + Seek>(
+        &self,
+        writer: &mut W,
+        args: Self::Args<'_>,
+    ) -> BinResult<()> {
         self.write_options(writer, Endian::Little, args)
     }
 
@@ -131,7 +139,7 @@ pub trait BinWrite {
         &self,
         writer: &mut W,
         endian: Endian,
-        args: Self::Args,
+        args: Self::Args<'_>,
     ) -> BinResult<()>;
 }
 
@@ -159,7 +167,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
     fn write_type<T: BinWrite>(&mut self, value: &T, endian: Endian) -> BinResult<()>
     where
-        T::Args: Required,
+        for<'a> T::Args<'a>: Required,
     {
         self.write_type_args(value, endian, T::Args::args())
     }
@@ -171,7 +179,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
     fn write_be<T: BinWrite>(&mut self, value: &T) -> BinResult<()>
     where
-        T::Args: Required,
+        for<'a> T::Args<'a>: Required,
     {
         self.write_type(value, Endian::Big)
     }
@@ -183,7 +191,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
     fn write_le<T: BinWrite>(&mut self, value: &T) -> BinResult<()>
     where
-        T::Args: Required,
+        for<'a> T::Args<'a>: Required,
     {
         self.write_type(value, Endian::Little)
     }
@@ -195,7 +203,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
     fn write_ne<T: BinWrite>(&mut self, value: &T) -> BinResult<()>
     where
-        T::Args: Required,
+        for<'a> T::Args<'a>: Required,
     {
         self.write_type(value, Endian::NATIVE)
     }
@@ -209,7 +217,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
         &mut self,
         value: &T,
         endian: Endian,
-        args: T::Args,
+        args: T::Args<'_>,
     ) -> BinResult<()> {
         T::write_options(value, self, endian, args)?;
 
@@ -222,7 +230,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// # Errors
     ///
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
-    fn write_be_args<T: BinWrite>(&mut self, value: &T, args: T::Args) -> BinResult<()> {
+    fn write_be_args<T: BinWrite>(&mut self, value: &T, args: T::Args<'_>) -> BinResult<()> {
         self.write_type_args(value, Endian::Big, args)
     }
 
@@ -232,7 +240,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// # Errors
     ///
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
-    fn write_le_args<T: BinWrite>(&mut self, value: &T, args: T::Args) -> BinResult<()> {
+    fn write_le_args<T: BinWrite>(&mut self, value: &T, args: T::Args<'_>) -> BinResult<()> {
         self.write_type_args(value, Endian::Little, args)
     }
 
@@ -242,7 +250,7 @@ pub trait BinWriterExt: Write + Seek + Sized {
     /// # Errors
     ///
     /// If writing fails, an [`Error`](crate::Error) variant will be returned.
-    fn write_ne_args<T: BinWrite>(&mut self, value: &T, args: T::Args) -> BinResult<()> {
+    fn write_ne_args<T: BinWrite>(&mut self, value: &T, args: T::Args<'_>) -> BinResult<()> {
         self.write_type_args(value, Endian::NATIVE, args)
     }
 }

--- a/binrw/src/io/no_std/mod.rs
+++ b/binrw/src/io/no_std/mod.rs
@@ -394,3 +394,20 @@ impl Write for Vec<u8> {
         Ok(())
     }
 }
+
+impl<W: Write + ?Sized> Write for &mut W {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (**self).write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<()> {
+        (**self).flush()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (**self).write_all(buf)
+    }
+}

--- a/binrw/src/io/no_std/mod.rs
+++ b/binrw/src/io/no_std/mod.rs
@@ -162,6 +162,16 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        (**self).read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
+        (**self).read_to_string(buf)
+    }
+
+    #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         (**self).read_exact(buf)
     }

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -122,8 +122,12 @@ pub use binrw_derive::binrw;
 /// }
 ///
 /// #[binread]
-/// #[br(import_raw(args: GlobalArgs<T::Args>))]
-/// struct Container<T: BinRead> {
+/// #[br(import_raw(args: GlobalArgs<T::Args<'_>>))]
+/// struct Container<T>
+/// where
+///     T: BinRead + 'static,
+///     for<'a> T::Args<'a>: Clone,
+/// {
 ///     #[br(temp, if(args.version > 1, 16))]
 ///     count: u16,
 ///     #[br(args {

--- a/binrw/src/pos_value.rs
+++ b/binrw/src/pos_value.rs
@@ -30,12 +30,12 @@ pub struct PosValue<T> {
 }
 
 impl<T: BinRead> BinRead for PosValue<T> {
-    type Args = T::Args;
+    type Args<'a> = T::Args<'a>;
 
     fn read_options<R: Read + Seek>(
         reader: &mut R,
         endian: Endian,
-        args: T::Args,
+        args: Self::Args<'_>,
     ) -> BinResult<Self> {
         let pos = reader.stream_position()?;
 
@@ -49,7 +49,7 @@ impl<T: BinRead> BinRead for PosValue<T> {
         &mut self,
         reader: &mut R,
         endian: Endian,
-        args: Self::Args,
+        args: Self::Args<'_>,
     ) -> BinResult<()> {
         self.val.after_parse(reader, endian, args)
     }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -74,7 +74,14 @@ where
 
 pub fn magic<R, B>(reader: &mut R, expected: B, endian: Endian) -> BinResult<()>
 where
-    B: BinRead<Args = ()> + core::fmt::Debug + PartialEq + Sync + Send + Clone + Copy + 'static,
+    B: for<'a> BinRead<Args<'a> = ()>
+        + core::fmt::Debug
+        + PartialEq
+        + Sync
+        + Send
+        + Clone
+        + Copy
+        + 'static,
     R: Read + Seek,
 {
     let pos = reader.stream_position()?;
@@ -91,7 +98,6 @@ where
 
 pub fn parse_fn_type_hint<Ret, ParseFn, R, Args>(f: ParseFn) -> ParseFn
 where
-    Args: Clone,
     R: Read + Seek,
     ParseFn: FnOnce(&mut R, Endian, Args) -> BinResult<Ret>,
 {
@@ -117,14 +123,13 @@ where
 pub fn map_args_type_hint<Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
 where
     MapFn: FnOnce(Input) -> Output,
-    Input: BinRead<Args = Args>,
+    Input: for<'a> BinRead<Args<'a> = Args>,
 {
     args
 }
 
 pub fn write_fn_type_hint<T, WriterFn, Writer, Args>(x: WriterFn) -> WriterFn
 where
-    Args: Clone,
     Writer: Write + Seek,
     WriterFn: FnOnce(&T, &mut Writer, Endian, Args) -> BinResult<()>,
 {
@@ -134,7 +139,7 @@ where
 pub fn write_map_args_type_hint<Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
 where
     MapFn: FnOnce(Input) -> Output,
-    Output: BinWrite<Args = Args>,
+    Output: for<'a> BinWrite<Args<'a> = Args>,
 {
     args
 }
@@ -146,7 +151,7 @@ pub fn write_try_map_args_type_hint<Input, Output, Error, MapFn, Args>(
 where
     Error: CustomError,
     MapFn: FnOnce(Input) -> Result<Output, Error>,
-    Output: BinWrite<Args = Args>,
+    Output: for<'a> BinWrite<Args<'a> = Args>,
 {
     args
 }

--- a/binrw/src/punctuated.rs
+++ b/binrw/src/punctuated.rs
@@ -43,7 +43,11 @@ pub struct Punctuated<T: BinRead, P: BinRead> {
     pub separators: Vec<P>,
 }
 
-impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
+impl<T, P> Punctuated<T, P>
+where
+    T: BinRead,
+    P: for<'a> BinRead<Args<'a> = ()>,
+{
     /// Parses values of type `T` separated by values of type `P` without a
     /// trailing separator value.
     ///
@@ -72,7 +76,10 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     /// # assert_eq!(y.x.separators, vec![0, 1]);
     /// ```
     #[crate::parser(reader, endian)]
-    pub fn separated(args: VecArgs<T::Args>, ...) -> BinResult<Self> {
+    pub fn separated<'a>(args: VecArgs<T::Args<'a>>, ...) -> BinResult<Self>
+    where
+        T::Args<'a>: Clone,
+    {
         let mut data = Vec::with_capacity(args.count);
         let mut separators = Vec::with_capacity(args.count.max(1) - 1);
 
@@ -95,7 +102,10 @@ impl<T: BinRead, P: BinRead<Args = ()>> Punctuated<T, P> {
     ///
     /// If reading fails, an [`Error`](crate::Error) variant will be returned.
     #[crate::parser(reader, endian)]
-    pub fn separated_trailing(args: VecArgs<T::Args>, ...) -> BinResult<Self> {
+    pub fn separated_trailing<'a>(args: VecArgs<T::Args<'a>>, ...) -> BinResult<Self>
+    where
+        T::Args<'a>: Clone,
+    {
         let mut data = Vec::with_capacity(args.count);
         let mut separators = Vec::with_capacity(args.count);
 

--- a/binrw/src/strings.rs
+++ b/binrw/src/strings.rs
@@ -34,12 +34,12 @@ pub struct NullString(
 );
 
 impl BinRead for NullString {
-    type Args = ();
+    type Args<'a> = ();
 
     fn read_options<R: Read + Seek>(
         reader: &mut R,
         endian: Endian,
-        _: Self::Args,
+        _: Self::Args<'_>,
     ) -> BinResult<Self> {
         let mut values = vec![];
 
@@ -54,13 +54,13 @@ impl BinRead for NullString {
 }
 
 impl BinWrite for NullString {
-    type Args = ();
+    type Args<'a> = ();
 
     fn write_options<W: Write + Seek>(
         &self,
         writer: &mut W,
         endian: Endian,
-        args: Self::Args,
+        args: Self::Args<'_>,
     ) -> BinResult<()> {
         self.0.write_options(writer, endian, args)?;
         0u8.write_options(writer, endian, args)?;
@@ -156,12 +156,12 @@ pub struct NullWideString(
 );
 
 impl BinRead for NullWideString {
-    type Args = ();
+    type Args<'a> = ();
 
     fn read_options<R: Read + Seek>(
         reader: &mut R,
         endian: Endian,
-        _: Self::Args,
+        _: Self::Args<'_>,
     ) -> BinResult<Self> {
         let mut values = vec![];
 
@@ -176,13 +176,13 @@ impl BinRead for NullWideString {
 }
 
 impl BinWrite for NullWideString {
-    type Args = ();
+    type Args<'a> = ();
 
     fn write_options<W: Write + Seek>(
         &self,
         writer: &mut W,
         endian: Endian,
-        args: Self::Args,
+        args: Self::Args<'_>,
     ) -> BinResult<()> {
         self.0.write_options(writer, endian, args)?;
         0u16.write_options(writer, endian, args)?;

--- a/binrw/tests/after_parse_test.rs
+++ b/binrw/tests/after_parse_test.rs
@@ -11,9 +11,12 @@ fn BinReaderExt_calls_after_parse() {
 #[test]
 fn try_calls_after_parse() {
     #[derive(BinRead)]
-    struct Try<BR: BinRead<Args = Args>, Args: Default + 'static>(#[br(try)] Option<BR>);
+    struct Try<BR>(#[br(try)] Option<BR>)
+    where
+        BR: BinRead,
+        for<'a> BR::Args<'a>: Default + 'static;
 
-    let test: Try<FilePtr8<u8>, _> = Cursor::new([0x01, 0xFF]).read_be().unwrap();
+    let test: Try<FilePtr8<u8>> = Cursor::new([0x01, 0xFF]).read_be().unwrap();
 
     assert_eq!(*test.0.unwrap(), 0xFF)
 }

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -229,6 +229,51 @@ fn all_default_imports() {
 }
 
 #[test]
+fn gat_list() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(little, import(borrowed: &u8))]
+    struct Test {
+        #[br(calc(*borrowed))]
+        a: u8,
+    }
+
+    assert_eq!(
+        Test::read_args(&mut Cursor::new(b""), (&1_u8,)).unwrap(),
+        Test { a: 1 }
+    );
+}
+
+#[test]
+fn gat_named() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(little, import { borrowed: &u8 })]
+    struct Test {
+        #[br(calc(*borrowed))]
+        a: u8,
+    }
+
+    assert_eq!(
+        Test::read_args(&mut Cursor::new(b""), binrw::args! { borrowed: &1_u8 }).unwrap(),
+        Test { a: 1 }
+    );
+}
+
+#[test]
+fn gat_raw() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(little, import_raw(borrowed: &u8))]
+    struct Test {
+        #[br(calc(*borrowed))]
+        a: u8,
+    }
+
+    assert_eq!(
+        Test::read_args(&mut Cursor::new(b""), &1_u8).unwrap(),
+        Test { a: 1 }
+    );
+}
+
+#[test]
 fn if_alternate() {
     #[derive(BinRead, Debug)]
     #[br(import{ try_read: bool })]

--- a/binrw/tests/derive/struct_generic.rs
+++ b/binrw/tests/derive/struct_generic.rs
@@ -3,7 +3,7 @@ use binrw::{io::Cursor, BinRead};
 #[test]
 fn derive_generic() {
     #[derive(BinRead)]
-    struct Test<T: BinRead<Args = ()> + Default> {
+    struct Test<T: for<'a> BinRead<Args<'a> = ()> + Default> {
         a: [T; 3],
     }
 

--- a/binrw/tests/derive/write/import.rs
+++ b/binrw/tests/derive/write/import.rs
@@ -1,4 +1,4 @@
-use binrw::{binrw, BinWrite};
+use binrw::{binrw, io::Cursor, BinWrite};
 
 #[test]
 fn correct_args_type_set() {
@@ -6,11 +6,58 @@ fn correct_args_type_set() {
     #[bw(import { _x: u32, _y: u8 })]
     struct Test {}
 
-    let mut x = binrw::io::Cursor::new(Vec::new());
+    let mut x = Cursor::new(Vec::new());
 
     Test {}
         .write_le_args(&mut x, binrw::args! { _x: 3, _y: 2 })
         .unwrap();
+}
+
+#[test]
+fn gat_list() {
+    #[derive(BinWrite)]
+    #[bw(little, import(borrowed: &u8))]
+    struct Test {
+        #[bw(map = |a| *a + *borrowed)]
+        a: u8,
+    }
+
+    let mut out = Cursor::new(Vec::new());
+    Test { a: 0 }.write_args(&mut out, (&1_u8,)).unwrap();
+
+    assert_eq!(out.into_inner(), b"\x01");
+}
+
+#[test]
+fn gat_named() {
+    #[derive(BinWrite)]
+    #[bw(little, import { borrowed: &u8 })]
+    struct Test {
+        #[bw(map = |a| *a + *borrowed)]
+        a: u8,
+    }
+
+    let mut out = Cursor::new(Vec::new());
+    Test { a: 0 }
+        .write_args(&mut out, binrw::args! { borrowed: &1_u8, })
+        .unwrap();
+
+    assert_eq!(out.into_inner(), b"\x01");
+}
+
+#[test]
+fn gat_raw() {
+    #[derive(BinWrite)]
+    #[bw(little, import_raw(borrowed: &u8))]
+    struct Test {
+        #[bw(map = |a| *a + *borrowed)]
+        a: u8,
+    }
+
+    let mut out = Cursor::new(Vec::new());
+    Test { a: 0 }.write_args(&mut out, &1_u8).unwrap();
+
+    assert_eq!(out.into_inner(), b"\x01");
 }
 
 #[test]
@@ -23,7 +70,7 @@ fn usable_args() {
         x_copy: u32,
     }
 
-    let mut x = binrw::io::Cursor::new(Vec::new());
+    let mut x = Cursor::new(Vec::new());
 
     Test {}
         .write_le_args(&mut x, binrw::args! { x: 3, _y: 2 })

--- a/binrw/tests/ui/args_vec_mistakes.stderr
+++ b/binrw/tests/ui/args_vec_mistakes.stderr
@@ -82,5 +82,5 @@ error[E0277]: the trait bound `VecArgs<()>: Default` is not satisfied
 note: required by a bound in `binrw::BinRead::read`
   --> src/binread/mod.rs
    |
-   |         Self::Args: Required,
-   |                     ^^^^^^^^ required by this bound in `binrw::BinRead::read`
+   |         for<'a> Self::Args<'a>: Required,
+   |                                 ^^^^^^^^ required by this bound in `binrw::BinRead::read`

--- a/binrw_derive/Cargo.toml
+++ b/binrw_derive/Cargo.toml
@@ -21,11 +21,11 @@ either = "1.8"
 owo-colors = { version = "3", optional = true }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
-syn = { version = "1", features = ["extra-traits", "full"] }
+syn = { version = "1", features = ["extra-traits", "fold", "full", "visit"] }
 
 [dev-dependencies]
 runtime-macros-derive = "0.4.0"
 
 [features]
 default = []
-verbose-backtrace = ["owo-colors", "syn/visit"]
+verbose-backtrace = ["owo-colors"]

--- a/binrw_derive/src/binrw/codegen/read_options/struct.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/struct.rs
@@ -409,7 +409,7 @@ impl<'field> FieldGenerator<'field> {
                     }
                     Map::None => {
                         quote_spanned! {ty.span()=>
-                            let #args_var: <#ty as #BINREAD_TRAIT>::Args = #args;
+                            let #args_var: <#ty as #BINREAD_TRAIT>::Args<'_> = #args;
                         }
                     }
                 }

--- a/binrw_derive/src/binrw/codegen/sanitization.rs
+++ b/binrw_derive/src/binrw/codegen/sanitization.rs
@@ -20,6 +20,8 @@ macro_rules! from_write_trait {
     };
 }
 
+pub(crate) const ARGS_LIFETIME: &str = "__binrw_generated_args_lifetime";
+
 ident_str! {
     pub(crate) BINREAD_TRAIT = from_read_trait!();
     pub(crate) BINWRITE_TRAIT = from_write_trait!();

--- a/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
@@ -231,7 +231,7 @@ impl<'a> StructFieldGenerator<'a> {
                 Map::None => {
                     let ty = &self.field.ty;
                     quote! {
-                        let #args: <#ty as #BINWRITE_TRAIT>::Args = #args_val;
+                        let #args: <#ty as #BINWRITE_TRAIT>::Args<'_> = #args_val;
                         #out
                     }
                 }

--- a/binrw_derive/src/named_args/codegen.rs
+++ b/binrw_derive/src/named_args/codegen.rs
@@ -422,19 +422,16 @@ impl BuilderField {
     }
 }
 
-impl From<&IdentTypeMaybeDefault> for BuilderField {
-    fn from(import: &IdentTypeMaybeDefault) -> Self {
-        let name = import.ident.clone();
-        let ty = import.ty.clone();
+impl From<IdentTypeMaybeDefault> for BuilderField {
+    fn from(import: IdentTypeMaybeDefault) -> Self {
+        let name = import.ident;
+        let ty = import.ty;
 
         // if no default is provided, mark as required
         let kind = import
             .default
-            .as_ref()
             .map_or(BuilderFieldKind::Required, |default| {
-                BuilderFieldKind::Optional {
-                    default: default.clone(),
-                }
+                BuilderFieldKind::Optional { default }
             });
 
         BuilderField { name, ty, kind }

--- a/binrw_derive/src/named_args/mod.rs
+++ b/binrw_derive/src/named_args/mod.rs
@@ -18,12 +18,13 @@ pub(crate) fn arg_type_name(ty_name: &Ident, is_write: bool) -> Ident {
     }
 }
 
-pub(crate) fn derive_from_imports<'a>(
+pub(crate) fn derive_from_imports(
     ty_name: &Ident,
     is_write: bool,
     result_name: &Ident,
     vis: &Visibility,
-    args: impl Iterator<Item = &'a IdentTypeMaybeDefault>,
+    lifetime: Option<syn::Lifetime>,
+    args: impl Iterator<Item = IdentTypeMaybeDefault>,
 ) -> TokenStream {
     let builder_name = &if is_write {
         format_ident!("{}BinWriteArgBuilder", ty_name, span = Span::mixed_site())
@@ -37,7 +38,10 @@ pub(crate) fn derive_from_imports<'a>(
         builder_name,
         result_name,
         fields: &args.map(Into::into).collect::<Vec<_>>(),
-        generics: &[],
+        generics: lifetime
+            .map(|lifetime| [syn::GenericParam::Lifetime(syn::LifetimeDef::new(lifetime))])
+            .as_ref()
+            .map_or(&[], |generics| generics.as_slice()),
         vis,
     }
     .generate(true)


### PR DESCRIPTION
Pretty much does what it says, probably; I don’t understand something fundamental about how GAT lifetimes and/or HRTB lifetimes work, so the fact that every thing seems to be working OK is probably a miracle rather than anything deliberate on my part. Borrows with anonymous lifetimes (elided in type references or `'_`) in the `import` directive are converted to use the macro-generated args type lifetime.