### PR TITLE
Add fallible `try_calc` directive

### DIFF
--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -575,6 +575,22 @@ fn try_directive() {
 }
 
 #[test]
+fn try_calc() {
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(big, import(v: u32))]
+    struct Test {
+        #[br(try_calc = <_>::try_from(v))]
+        a: u16,
+    }
+
+    assert_eq!(
+        Test::read_args(&mut Cursor::new(b""), (1,)).unwrap(),
+        Test { a: 1 }
+    );
+    Test::read_args(&mut Cursor::new(b""), (0x1_0000,)).unwrap_err();
+}
+
+#[test]
 fn tuple() {
     #[derive(BinRead, Debug, Eq, PartialEq)]
     struct Test(#[br(big)] u16, #[br(little)] u16);

--- a/binrw/tests/derive/write/calc.rs
+++ b/binrw/tests/derive/write/calc.rs
@@ -44,3 +44,21 @@ fn calc_visibility() {
 
     assert_eq!(x.into_inner(), [1, 0, 2, 0, 3]);
 }
+
+#[test]
+fn try_calc() {
+    #[binwrite]
+    #[derive(Debug, PartialEq)]
+    #[bw(big, import(v: u32))]
+    struct Test {
+        #[bw(try_calc = <_>::try_from(v))]
+        a: u16,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    Test {}.write_args(&mut x, (1,)).unwrap();
+    assert_eq!(x.into_inner(), b"\0\x01");
+    Test {}
+        .write_args(&mut Cursor::new(Vec::new()), (0x1_0000,))
+        .unwrap_err();
+}

--- a/binrw/tests/ui/args_calc_conflict.stderr
+++ b/binrw/tests/ui/args_calc_conflict.stderr
@@ -1,4 +1,4 @@
-error: `args` is incompatible with `calc`
+error: `args` is incompatible with `calc` and `try_calc`
  --> tests/ui/args_calc_conflict.rs:5:5
   |
 5 | /     #[br(args(()), calc(None))]

--- a/binrw/tests/ui/binrw_br_temp_no_bw_ignore.stderr
+++ b/binrw/tests/ui/binrw_br_temp_no_bw_ignore.stderr
@@ -1,4 +1,4 @@
-error: `#[br(temp)]` is invalid without a corresponding `#[bw(ignore)]` or `#[bw(calc)]`
+error: `#[br(temp)]` is invalid without a corresponding `#[bw(ignore)]`, `#[bw(calc)]`, or `#[bw(try_calc)]`
  --> tests/ui/binrw_br_temp_no_bw_ignore.rs:5:5
   |
 5 | /     #[br(temp)]

--- a/binrw/tests/ui/invalid_keyword_struct_field.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct_field.stderr
@@ -1,5 +1,5 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
- --> $DIR/invalid_keyword_struct_field.rs:5:10
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+ --> tests/ui/invalid_keyword_struct_field.rs:5:10
   |
 5 |     #[br(invalid_struct_field_keyword)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -1,17 +1,17 @@
 error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
- --> $DIR/non_blocking_errors.rs:6:6
+ --> tests/ui/non_blocking_errors.rs:6:6
   |
 6 | #[br(invalid_keyword_struct)]
   |      ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
- --> $DIR/non_blocking_errors.rs:8:10
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+ --> tests/ui/non_blocking_errors.rs:8:10
   |
 8 |     #[br(invalid_keyword_struct_field_a)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
-  --> $DIR/non_blocking_errors.rs:10:10
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `offset_after`, `if`, `deref_now`, `postprocess_now`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+  --> tests/ui/non_blocking_errors.rs:10:10
    |
 10 |     #[br(invalid_keyword_struct_field_b)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/binrw/tests/ui/try_calc_conflict.stderr
+++ b/binrw/tests/ui/try_calc_conflict.stderr
@@ -1,5 +1,5 @@
-error: `try` is incompatible with `default` and `calc`
- --> $DIR/try_calc_conflict.rs:5:10
+error: `try` is incompatible with `default`, `calc`, and `try_calc`
+ --> tests/ui/try_calc_conflict.rs:5:10
   |
 5 |     #[br(try, calc(None))]
   |          ^^^

--- a/binrw/tests/ui/try_default_conflict.stderr
+++ b/binrw/tests/ui/try_default_conflict.stderr
@@ -1,5 +1,5 @@
-error: `try` is incompatible with `default` and `calc`
- --> $DIR/try_default_conflict.rs:5:10
+error: `try` is incompatible with `default`, `calc`, and `try_calc`
+ --> tests/ui/try_default_conflict.rs:5:10
   |
 5 |     #[br(try, default)]
   |          ^^^

--- a/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
+++ b/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
@@ -249,7 +249,9 @@ fn visit_expr_attributes(field: &StructField, visitor: &mut Visitor) {
         PassedArgs::None => (),
     }
 
-    if let FieldMode::Calc(expr) | FieldMode::Function(expr) = &field.read_mode {
+    if let FieldMode::Calc(expr) | FieldMode::TryCalc(expr) | FieldMode::Function(expr) =
+        &field.field_mode
+    {
         visit!(expr.clone());
     }
 

--- a/binrw_derive/src/binrw/codegen/read_options.rs
+++ b/binrw_derive/src/binrw/codegen/read_options.rs
@@ -3,17 +3,12 @@ mod map;
 mod r#struct;
 
 use super::{get_assertions, get_destructured_imports};
-use crate::{
-    binrw::{
-        codegen::{
-            get_endian,
-            sanitization::{
-                ARGS, ASSERT_MAGIC, BIN_ERROR, OPT, POS, READER, SEEK_FROM, SEEK_TRAIT,
-            },
-        },
-        parser::{Input, Magic, Map},
+use crate::binrw::{
+    codegen::{
+        get_endian,
+        sanitization::{ARGS, ASSERT_MAGIC, OPT, POS, READER, SEEK_FROM, SEEK_TRAIT},
     },
-    util::IdentStr,
+    parser::{Input, Magic, Map},
 };
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -125,15 +120,4 @@ fn get_magic(magic: &Magic, endian_var: impl ToTokens) -> Option<TokenStream> {
             #ASSERT_MAGIC(#READER, #magic, #endian_var)?;
         }
     })
-}
-
-fn get_map_err(pos: IdentStr) -> TokenStream {
-    quote! {
-        .map_err(|e| {
-            #BIN_ERROR::Custom {
-                pos: #pos,
-                err: Box::new(e) as _,
-            }
-        })
-    }
 }

--- a/binrw_derive/src/binrw/codegen/read_options/map.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/map.rs
@@ -1,14 +1,14 @@
-use super::{get_map_err, PreludeGenerator};
+use super::PreludeGenerator;
 use crate::binrw::{
     codegen::{
-        get_assertions,
+        get_assertions, get_map_err,
         sanitization::{ARGS, OPT, POS, READER, READ_METHOD},
     },
     parser::Input,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Ident;
+use syn::{spanned::Spanned, Ident};
 
 pub(crate) fn generate_map(input: &Input, name: Option<&Ident>, map: &TokenStream) -> TokenStream {
     let prelude = PreludeGenerator::new(input)
@@ -46,7 +46,7 @@ pub(crate) fn generate_try_map(
     name: Option<&Ident>,
     map: &TokenStream,
 ) -> TokenStream {
-    let map_err = get_map_err(POS);
+    let map_err = get_map_err(POS, map.span());
     let prelude = PreludeGenerator::new(input)
         .add_imports(name)
         .add_endian()

--- a/binrw_derive/src/binrw/combiner.rs
+++ b/binrw_derive/src/binrw/combiner.rs
@@ -1,7 +1,7 @@
 use crate::{
     binrw::{
         codegen::generate_impl,
-        parser::{Enum, EnumVariant, FieldMode, Input, ParseResult, Struct, StructField},
+        parser::{Enum, EnumVariant, Input, ParseResult, Struct, StructField},
         Options,
     },
     combine_error,
@@ -127,14 +127,12 @@ fn validate_fields_temporary(
 ) -> Option<syn::Error> {
     let mut all_errors = None::<syn::Error>;
     for field in fields {
-        if read_temporary.contains(&field.ident)
-            && !matches!(field.read_mode, FieldMode::Calc(_) | FieldMode::Default)
-        {
+        if read_temporary.contains(&field.ident) && !field.generated_value() {
             combine_error(
                 &mut all_errors,
                 syn::Error::new(
                     field.field.span(),
-                    "`#[br(temp)]` is invalid without a corresponding `#[bw(ignore)]` or `#[bw(calc)]`",
+                    "`#[br(temp)]` is invalid without a corresponding `#[bw(ignore)]`, `#[bw(calc)]`, or `#[bw(try_calc)]`",
                 ),
             );
         }

--- a/binrw_derive/src/binrw/parser/attrs.rs
+++ b/binrw_derive/src/binrw/parser/attrs.rs
@@ -42,5 +42,6 @@ pub(super) type ReturnUnexpectedError = MetaVoid<kw::return_unexpected_error>;
 pub(super) type SeekBefore = MetaExpr<kw::seek_before>;
 pub(super) type Temp = MetaVoid<kw::temp>;
 pub(super) type Try = MetaVoid<Token![try]>;
+pub(super) type TryCalc = MetaExpr<kw::try_calc>;
 pub(super) type TryMap = MetaExpr<kw::try_map>;
 pub(super) type WriteWith = MetaExpr<kw::write_with>;

--- a/binrw_derive/src/binrw/parser/keywords.rs
+++ b/binrw_derive/src/binrw/parser/keywords.rs
@@ -46,6 +46,7 @@ define_keywords! {
     return_unexpected_error,
     seek_before,
     temp,
+    try_calc,
     try_map,
     write_with,
 }

--- a/binrw_derive/src/binrw/parser/types/field_mode.rs
+++ b/binrw_derive/src/binrw/parser/types/field_mode.rs
@@ -10,6 +10,7 @@ pub(crate) enum FieldMode {
     Normal,
     Default,
     Calc(TokenStream),
+    TryCalc(TokenStream),
     Function(TokenStream),
 }
 
@@ -34,6 +35,12 @@ impl From<attrs::Default> for FieldMode {
 impl From<attrs::Calc> for FieldMode {
     fn from(calc: attrs::Calc) -> Self {
         Self::Calc(calc.into_token_stream())
+    }
+}
+
+impl From<attrs::TryCalc> for FieldMode {
+    fn from(calc: attrs::TryCalc) -> Self {
+        Self::TryCalc(calc.into_token_stream())
     }
 }
 


### PR DESCRIPTION
Questions:

1. There is somewhat of a proliferation of infallible directives and then later on a fallible one. Is there a better/more generalisable way to handle this?
2. Should it be wrapped by some closure in the codegen so the try-operator can also be used to return early?