### PR TITLE
Fix single-arg parser/writers

### DIFF
--- a/binrw/tests/derive/fn_helper.rs
+++ b/binrw/tests/derive/fn_helper.rs
@@ -1,0 +1,27 @@
+use binrw::{binrw, io::Cursor, BinReaderExt, BinResult, BinWriterExt};
+
+#[binrw::parser]
+fn single_arg_parser(arg: u32) -> BinResult<u32> {
+    Ok(arg)
+}
+
+#[binrw::writer(writer)]
+fn single_arg_writer(_object: &u32, arg: u32) -> BinResult<()> {
+    writer.write_le(&arg)
+}
+
+#[binrw]
+struct SingleArg {
+    #[br(parse_with = single_arg_parser, args(0x42u32))]
+    #[bw(write_with = single_arg_writer, args(0x42u32))]
+    field: u32,
+}
+
+#[test]
+fn single_arg() {
+    let result: SingleArg = Cursor::new(b"").read_le().unwrap();
+    assert_eq!(result.field, 0x42);
+    let mut written = Cursor::new(Vec::new());
+    written.write_le(&result).unwrap();
+    assert_eq!(written.into_inner(), b"\x42\x00\x00\x00");
+}

--- a/binrw/tests/derive/mod.rs
+++ b/binrw/tests/derive/mod.rs
@@ -1,5 +1,6 @@
 mod binwrite_temp;
 mod r#enum;
+mod fn_helper;
 mod map_args;
 mod r#struct;
 mod struct_generic;

--- a/binrw_derive/src/fn_helper/mod.rs
+++ b/binrw_derive/src/fn_helper/mod.rs
@@ -103,6 +103,12 @@ fn generate<const WRITE: bool>(
             }
         }
 
+        if args_ty.len() == 1 {
+            // Add trailing comma so it's a single-element tuple, not a parenthesized item
+            args_pat.push_punct(parse_quote!(,));
+            args_ty.push_punct(parse_quote!(,));
+        }
+
         func.sig.inputs.push(parse_quote!((#args_pat): (#args_ty)));
     }
 


### PR DESCRIPTION
There was a problem with tuple-args in `#[parser]`/`#[writer]`:
```rust
#[binrw::parser]
fn single_arg_parser(arg: u32) -> BinResult<u32> {
    Ok(arg)
}

#[binrw::binread]
struct SingleArg {
    #[br(parse_with = single_arg_parser, args(42u32))]
    field: u32,
}
```
[compiles]
```rust
10  |     #[br(parse_with = single_arg_parser, args(42u32))]
    |                                          ^^^^ expected `u32`, found `(u32,)`
```

It was missing a trailing comma to correctly make it a tuple, instead emitting `(arg): (u32)` which is equivalent to `arg: u32`.