### PR TITLE
use `expect` so clippy does not complain

### DIFF
--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -321,7 +321,7 @@ fn directives_to_args(field: &StructField) -> TokenStream {
     let args = field
         .count
         .as_ref()
-        .map(|count| quote_spanned! { count.span()=> count: usize::try_from(#count).unwrap() })
+        .map(|count| quote_spanned! { count.span()=> count: usize::try_from(#count).expect("error converting count to usize") })
         .into_iter()
         .chain(
             field


### PR DESCRIPTION
Currently, when using `#[br(count = x)]` above a field in a `struct`, clippy will complain that `unwrap` is being used (within the macro). No variation of `#[allow()]` seemed to silence the problem.

This happens because `#![warn(clippy::unwrap_used)]` is being used throughout the crate I'm working on - it's annoying but helps catch some (potential) issues, so I figure a fix here will likely be the best solution (and hopefully prevent this issue happening to others, too).