### PR TITLE
Fix: don't warn on useless conversions when the count value is already a usize

### DIFF
--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -325,6 +325,7 @@ fn directives_to_args(field: &StructField, stream: IdentStr) -> TokenStream {
             quote_spanned_any! {count.span()=>
                 count: {
                     let #TEMP = #count;
+                    #[allow(clippy::useless_conversion)]
                     usize::try_from(#TEMP).map_err(|_| {
                         extern crate alloc;
                         #BIN_ERROR::AssertFail {

--- a/binrw_derive/src/binrw/codegen/sanitization.rs
+++ b/binrw_derive/src/binrw/codegen/sanitization.rs
@@ -1,4 +1,4 @@
-///! Utilities for helping sanitize macro
+//! Utilities for helping sanitize macro
 use crate::util::{from_crate, ident_str};
 use proc_macro2::Ident;
 use quote::format_ident;


### PR DESCRIPTION
- nit: fix doc comment that applied to use and not module
- fix: don't warn on useless conversions when the value is already a usize

Example code to reproduce the issue: (run `cargo clippy`)

```rust
const LEN: usize = 42;

#[derive(binrw::BinRead)]
struct Data {
    #[br(count = LEN)]
    data: Vec<u8>,
}
```
