### PR TITLE
Allow self in non-unit struct and enum top-level assert

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -502,6 +502,15 @@ Any <span class="brw">(earlier only, when reading)</span><span class="br">earlie
 field or [import](#arguments) can be referenced by expressions
 in the directive.
 
+<div class="br">
+
+For `#[br]`, when using `map`, a non-unit `struct`, or an `enum`, a special variable
+named `self` can be referenced by expressions in the directive. It contains the result
+of the `map` function or the result of constructing the `struct` or `enum`. Note that
+you cannot refer to the `enum` fields directly, as an `enum` variant is not its own type.
+
+</div>
+
 ## Examples
 
 ### Formatted error

--- a/binrw/tests/derive/map_args.rs
+++ b/binrw/tests/derive/map_args.rs
@@ -48,3 +48,27 @@ fn map_field_assert_access_fields() {
 
     Test::read(&mut Cursor::new(b"a")).unwrap();
 }
+
+#[test]
+#[should_panic]
+fn map_top_assert_legacy_this() {
+    #[derive(BinRead, Debug, Eq, PartialEq)]
+    #[br(assert(this.x == 2), map(|_: u8| Test { x: 3 }))]
+    struct Test {
+        x: u8,
+    }
+
+    Test::read(&mut Cursor::new(b"a")).unwrap();
+}
+
+#[test]
+#[should_panic]
+fn map_top_assert_via_self() {
+    #[derive(BinRead, Debug, Eq, PartialEq)]
+    #[br(assert(self.x == 2), map(|_: u8| Test { x: 3 }))]
+    struct Test {
+        x: u8,
+    }
+
+    Test::read(&mut Cursor::new(b"a")).unwrap();
+}

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -731,6 +731,32 @@ fn top_level_assert_has_self() {
 }
 
 #[test]
+fn top_level_assert_self_weird() {
+    #[allow(dead_code)]
+    #[derive(BinRead, Debug)]
+    #[br(assert(Test::verify(&self), "verify failed"))]
+    struct Test {
+        a: u8,
+        b: u8,
+    }
+
+    impl Test {
+        fn verify(&self) -> bool {
+            self.a == self.b
+        }
+    }
+
+    let mut data = Cursor::new(b"\x01\x01");
+    Test::read_le(&mut data).expect("a == b passed");
+    let mut data = Cursor::new(b"\x01\x02");
+    let err = Test::read_le(&mut data).expect_err("a == b failed");
+    assert!(matches!(err, binrw::Error::AssertFail {
+        message,
+        ..
+    } if message == "verify failed"));
+}
+
+#[test]
 fn rewind_on_assert() {
     #[allow(dead_code)]
     #[derive(BinRead, Debug)]

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -705,6 +705,32 @@ fn reader_var() {
 }
 
 #[test]
+fn top_level_assert_has_self() {
+    #[allow(dead_code)]
+    #[derive(BinRead, Debug)]
+    #[br(assert(self.verify(), "verify failed"))]
+    struct Test {
+        a: u8,
+        b: u8,
+    }
+
+    impl Test {
+        fn verify(&self) -> bool {
+            self.a == self.b
+        }
+    }
+
+    let mut data = Cursor::new(b"\x01\x01");
+    Test::read_le(&mut data).expect("a == b passed");
+    let mut data = Cursor::new(b"\x01\x02");
+    let err = Test::read_le(&mut data).expect_err("a == b failed");
+    assert!(matches!(err, binrw::Error::AssertFail {
+        message,
+        ..
+    } if message == "verify failed"));
+}
+
+#[test]
 fn rewind_on_assert() {
     #[allow(dead_code)]
     #[derive(BinRead, Debug)]

--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -204,6 +204,7 @@ fn get_assertions(assertions: &[Assert]) -> impl Iterator<Item = TokenStream> + 
              kw_span,
              condition,
              consequent,
+             ..
          }| {
             let error_fn = match &consequent {
                 Some(AssertionError::Message(message)) => {

--- a/binrw_derive/src/binrw/codegen/read_options/enum.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/enum.rs
@@ -3,12 +3,9 @@ use super::{
     PreludeGenerator,
 };
 use crate::binrw::{
-    codegen::{
-        get_assertions,
-        sanitization::{
-            BACKTRACE_FRAME, BIN_ERROR, ERROR_BASKET, OPT, POS, READER, READ_METHOD,
-            RESTORE_POSITION_VARIANT, TEMP, WITH_CONTEXT,
-        },
+    codegen::sanitization::{
+        BACKTRACE_FRAME, BIN_ERROR, ERROR_BASKET, OPT, POS, READER, READ_METHOD,
+        RESTORE_POSITION_VARIANT, TEMP, WITH_CONTEXT,
     },
     parser::{Enum, EnumErrorMode, EnumVariant, Input, UnitEnumField, UnitOnlyEnum},
 };
@@ -228,8 +225,8 @@ fn generate_variant_impl(en: &Enum, variant: &EnumVariant) -> TokenStream {
                 None,
                 Some(&format!("{}::{}", en.ident.as_ref().unwrap(), &ident)),
             )
-            .add_assertions(get_assertions(&en.assertions))
-            .return_value(Some(ident))
+            .initialize_value_with_assertions(Some(ident), &en.assertions)
+            .return_value()
             .finish(),
 
         EnumVariant::Unit(options) => generate_unit_struct(&input, None, Some(&options.ident)),

--- a/binrw_derive/src/binrw/codegen/read_options/struct.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/struct.rs
@@ -1,6 +1,7 @@
 use super::{get_magic, PreludeGenerator};
 #[cfg(feature = "verbose-backtrace")]
 use crate::binrw::backtrace::BacktraceFrame;
+use crate::binrw::parser::Assert;
 use crate::{
     binrw::{
         codegen::{
@@ -20,7 +21,6 @@ use alloc::borrow::Cow;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{spanned::Spanned, Ident};
-use crate::binrw::parser::Assert;
 
 pub(super) fn generate_unit_struct(
     input: &Input,
@@ -85,8 +85,8 @@ impl<'input> StructGenerator<'input> {
     }
 
     fn add_assertions(mut self, extra_assertions: &[Assert]) -> Self {
-        let assertions = get_assertions(&self.st.assertions)
-            .chain(get_assertions(extra_assertions));
+        let assertions =
+            get_assertions(&self.st.assertions).chain(get_assertions(extra_assertions));
         let head = self.out;
         self.out = quote! {
             #head

--- a/binrw_derive/src/binrw/parser/types/assert.rs
+++ b/binrw_derive/src/binrw/parser/types/assert.rs
@@ -41,15 +41,16 @@ impl<K: Parse + Spanned + Token> TryFrom<attrs::AssertLike<K>> for Assert {
         // ignores any alternative declaration of `self` in the condition, but asserts should be
         // simple so that shouldn't be a problem
         let mut condition_uses_self = false;
-        let condition: TokenStream = condition.into_iter().map(|tt| {
-            match tt {
+        let condition: TokenStream = condition
+            .into_iter()
+            .map(|tt| match tt {
                 TokenTree::Ident(ref i) if i == "self" => {
                     condition_uses_self = true;
                     TokenTree::Ident(Ident::new("this", i.span()))
                 }
                 other => other,
-            }
-        }).collect();
+            })
+            .collect();
 
         let consequent = match args.next() {
             Some(Expr::Lit(ExprLit {


### PR DESCRIPTION
Also allows top-level map to use `self` instead of `this`.

Complete with documentation!