### PR TITLE
Remove unnecessary bounds from BinWrite for PhantomData impl

### DIFF
--- a/binrw/src/binwrite/impls.rs
+++ b/binrw/src/binwrite/impls.rs
@@ -194,8 +194,8 @@ impl<T: BinWrite> BinWrite for Option<T> {
     }
 }
 
-impl<T: BinWrite> BinWrite for PhantomData<T> {
-    type Args<'a> = T::Args<'a>;
+impl<T> BinWrite for PhantomData<T> {
+    type Args<'a> = ();
 
     fn write_options<W: Write + Seek>(
         &self,


### PR DESCRIPTION
Currently `BinWrite` (but not `BinRead`) impl for `PhantomData<T>` requires that `T: BinWrite`. This is unnecessary, as `PhantomData` doesn't actually store `T` and nothing is written.

This PR removes unnecessary trait bound