### PR TITLE
docs: link magic to pre_assert for the enum variant selection

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -1708,6 +1708,9 @@ object.write_le(&mut output)
 ```
 </div>
 
+Note the alternative approach for the enum variant selection is [`pre_assert`](#pre-assert) directive
+(where the [`argument`](#arguments)-based variant selection is supported).
+
 <div class="br">
 
 ## Errors


### PR DESCRIPTION
It took me a non-trivial time to realize that there's an alternative approach to the enum variant selection where one can make the selection based on a provided attribute.