### PR TITLE
Add SeekFrom::Start, SeekFrom::Current, and nested support to take_seek

### DIFF
--- a/binrw/tests/io/take_seek.rs
+++ b/binrw/tests/io/take_seek.rs
@@ -74,19 +74,20 @@ fn take_seek() {
     );
     assert_eq!(
         take.read(&mut buf).unwrap(),
-        5,
-        "`read` did not read enough after `SeemFrom::Start`"
-    );
-    assert_eq!(
-        take.read(&mut buf).unwrap(),
-        1,
+        0,
         "`read` read incorrect amount at end of stream"
     );
+    assert_eq!(&buf, b"worlb", "`read` read wrong data");
+
     assert_eq!(
         take.seek(SeekFrom::Start(0)).unwrap(),
         0,
         "`SeekFrom::Start` returned wrong position at end of stream"
     );
+
+    // Rewind the underlying cursor so we can start at the beginning of the
+    // buffer when `set_limit` is called.
+    take.get_mut().rewind().unwrap();
 
     take.set_limit(3);
     assert_eq!(
@@ -94,7 +95,7 @@ fn take_seek() {
         3,
         "`set_limit` caused too-large partial-limit read"
     );
-    assert_eq!(&buf, b"helrl", "`read` read wrong data");
+    assert_eq!(&buf, b"hellb", "`read` read wrong data");
 
     take.seek(SeekFrom::End(-5))
         .expect_err("out-of-range `SeekFrom::End` backward seek should fail");
@@ -130,4 +131,269 @@ fn take_seek_ref() {
     assert_eq!(&buf, b" worl");
     assert_eq!(data.take_seek(5).read(&mut buf).unwrap(), 1);
     assert_eq!(&buf, b"dworl");
+}
+
+#[test]
+fn test_seek_start() {
+    let mut buf = [0; 8];
+
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut section = data.take_seek(6);
+
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 6);
+    assert_eq!(section.read(&mut buf).unwrap(), 6);
+    assert_eq!(&buf, b"\x01\x02\x03\x04\x05\x06\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+
+    let mut buf = [0; 8]; // clear buff to ensure read works.
+
+    section.rewind().unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 6);
+    assert_eq!(section.read(&mut buf).unwrap(), 6);
+    assert_eq!(&buf, b"\x01\x02\x03\x04\x05\x06\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+}
+
+#[test]
+fn test_seek_relative() {
+    let mut buf = [0; 8];
+
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut section = data.take_seek(6);
+
+    section
+        .seek_relative(-1)
+        .expect_err("out-of-range `SeekFrom::Current` backward seek should fail");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 6);
+
+    section.seek_relative(2).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 3);
+    assert_eq!(section.stream_position().unwrap(), 2);
+    assert_eq!(section.limit(), 4);
+    assert_eq!(section.read(&mut buf).unwrap(), 4);
+    assert_eq!(&buf, b"\x03\x04\x05\x06\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+
+    section.seek_relative(-2).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 5);
+    assert_eq!(section.stream_position().unwrap(), 4);
+    assert_eq!(section.limit(), 2);
+    assert_eq!(section.read(&mut buf).unwrap(), 2);
+    assert_eq!(&buf, b"\x05\x06\x05\x06\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+
+    // According to `std::io::Seek.seek`, seeking past the stream is valid,
+    // but behavior is defined by the implementation. In our case we don't
+    // allow reading any additional data.
+    section.seek_relative(2).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 8);
+    assert_eq!(section.limit(), 0);
+    assert_eq!(section.read(&mut buf).unwrap(), 0);
+    assert_eq!(&buf, b"\x05\x06\x05\x06\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 8);
+}
+
+#[test]
+fn test_seek_end() {
+    let mut buf = [0; 8];
+
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut section = data.take_seek(6);
+
+    section.seek(SeekFrom::End(0)).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+    assert_eq!(section.limit(), 0);
+    assert_eq!(section.read(&mut buf).unwrap(), 0);
+    assert_eq!(&buf, b"\x00\x00\x00\x00\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+
+    section.seek(SeekFrom::End(-2)).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 5);
+    assert_eq!(section.stream_position().unwrap(), 4);
+    assert_eq!(section.limit(), 2);
+    assert_eq!(section.read(&mut buf).unwrap(), 2);
+    assert_eq!(&buf, b"\x05\x06\x00\x00\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 7);
+    assert_eq!(section.stream_position().unwrap(), 6);
+
+    // According to `std::io::Seek.seek`, seeking past the stream is valid,
+    // but behavior is defined by the implementation. In our case we don't
+    // allow reading any additional data.
+    section.seek(SeekFrom::End(2)).unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 8);
+    assert_eq!(section.limit(), 0);
+    assert_eq!(section.read(&mut buf).unwrap(), 0);
+    assert_eq!(&buf, b"\x05\x06\x00\x00\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 8);
+
+    section
+        .seek(SeekFrom::End(-10))
+        .expect_err("out-of-range `SeekFrom::End` backward seek should fail");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 8);
+    assert_eq!(section.limit(), 0);
+}
+
+#[test]
+fn test_seek_nested() {
+    let mut buf = [0; 8];
+
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut outer_section = data.take_seek(6);
+    outer_section.seek_relative(2).unwrap();
+    assert_eq!(outer_section.get_mut().stream_position().unwrap(), 3);
+    assert_eq!(outer_section.stream_position().unwrap(), 2);
+    assert_eq!(outer_section.limit(), 4);
+
+    // Will only allow reading data[3..5].
+    let mut inner_section = outer_section.take_seek(2);
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        3
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 2);
+    assert_eq!(inner_section.stream_position().unwrap(), 0);
+    assert_eq!(inner_section.limit(), 2);
+    assert_eq!(inner_section.read(&mut buf).unwrap(), 2);
+    assert_eq!(&buf, b"\x03\x04\x00\x00\x00\x00\x00\x00");
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        5
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 4);
+    assert_eq!(inner_section.stream_position().unwrap(), 2);
+
+    inner_section.rewind().unwrap();
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        3
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 2);
+    assert_eq!(inner_section.stream_position().unwrap(), 0);
+    assert_eq!(inner_section.get_mut().limit(), 4);
+    assert_eq!(inner_section.limit(), 2);
+
+    inner_section.seek_relative(1).unwrap();
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        4
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 3);
+    assert_eq!(inner_section.stream_position().unwrap(), 1);
+    assert_eq!(inner_section.get_mut().limit(), 3);
+    assert_eq!(inner_section.limit(), 1);
+
+    inner_section.seek(SeekFrom::End(0)).unwrap();
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        5
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 4);
+    assert_eq!(inner_section.stream_position().unwrap(), 2);
+    assert_eq!(inner_section.get_mut().limit(), 2);
+    assert_eq!(inner_section.limit(), 0);
+
+    // Seek past the end of the stream, it should seek `outer_section` to the end.
+    inner_section.seek(SeekFrom::End(2)).unwrap();
+    assert_eq!(
+        inner_section.get_mut().get_mut().stream_position().unwrap(),
+        7
+    );
+    assert_eq!(inner_section.get_mut().stream_position().unwrap(), 6);
+    assert_eq!(inner_section.stream_position().unwrap(), 4);
+    assert_eq!(inner_section.get_mut().limit(), 0);
+    assert_eq!(inner_section.limit(), 0);
+}
+
+#[test]
+fn test_empty() {
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut section = data.take_seek(0);
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 0);
+}
+
+#[test]
+fn test_set_limit() {
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut buf = [0; 8];
+
+    let mut section = data.take_seek(6);
+    section.seek(SeekFrom::End(-2)).unwrap();
+    section.set_limit(4);
+
+    assert_eq!(section.limit(), 4);
+    assert_eq!(section.read(&mut buf).unwrap(), 4);
+    assert_eq!(&buf, b"\x05\x06\x07\x08\x00\x00\x00\x00");
+}
+
+#[test]
+fn test_early_eof() {
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(6)).unwrap();
+
+    let mut buf = [0; 8];
+
+    let mut section = data.take_seek(10);
+
+    assert_eq!(section.limit(), 10);
+    assert_eq!(section.read(&mut buf).unwrap(), 3);
+    assert_eq!(&buf, b"\x06\x07\x08\x00\x00\x00\x00\x00");
+    assert_eq!(section.get_mut().stream_position().unwrap(), 9);
+    assert_eq!(section.stream_position().unwrap(), 3);
+    assert_eq!(section.limit(), 7);
+}
+
+#[test]
+fn test_corrupt_position() {
+    let mut data = Cursor::new("\x00\x01\x02\x03\x04\x05\x06\x07\x08");
+    data.seek(SeekFrom::Start(1)).unwrap();
+
+    let mut section = data.take_seek(2);
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 2);
+
+    // Move the underlying cursor before the start of the section. This
+    // is an invalid state.
+    section.get_mut().rewind().unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 0);
+    section
+        .stream_position()
+        .expect_err("invalid stream position");
+
+    // Fix the cursor by resetting the cursor position.
+    section.rewind().unwrap();
+    assert_eq!(section.get_mut().stream_position().unwrap(), 1);
+    assert_eq!(section.stream_position().unwrap(), 0);
+    assert_eq!(section.limit(), 2);
 }


### PR DESCRIPTION
This change adds support for the missing SeekFrom operations. It
refactors the internals a bit. We now keep a range of start..end values
that are accessible to the TakeSeek. I dropped manually computed stream
position and instead call the inner's `stream_position()`. This does
mean that `limit` needs to take in a `&mut`. I was also going to change
the return type to `Result<u64>`, but that would force all callers to
handle the `Result`, which I felt like it was a bigger API change.

I fixed the test added in 38b35989ffa27e8bb18cd91f69c6bcc66d2ca03e
because `StartFrom::Start(0)` used to reset the cursor to the start of
the underlying buffer.

Fixes jam1garner/binrw#291.
