### PR TITLE
Update to syn version 2

### DIFF
--- a/binrw/tests/ui/args_missing.stderr
+++ b/binrw/tests/ui/args_missing.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NoDefault: Default` is not satisfied
   --> tests/ui/args_missing.rs:12:8
    |
 12 |     a: Foo,
-   |        ^^^ the trait `Default` is not implemented for `NoDefault`, which is required by `(NoDefault,): MissingArgsDirective`
+   |        ^^^ the trait `Default` is not implemented for `NoDefault`
    |
    = note: required for `(NoDefault,)` to implement `Default`
    = note: required for `(NoDefault,)` to implement `MissingArgsDirective`

--- a/binrw/tests/ui/args_vec_mistakes.stderr
+++ b/binrw/tests/ui/args_vec_mistakes.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `VecArgs<()>: MissingArgsDirective` is not satisfi
  --> tests/ui/args_vec_mistakes.rs:7:20
   |
 7 | struct MissingArgs(Vec<u8>);
-  |                    ^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`, which is required by `VecArgs<()>: MissingArgsDirective`
+  |                    ^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`
   |
   = note: required for `VecArgs<()>` to implement `MissingArgsDirective`
 note: required by a bound in `Required::args`
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `usize: TryFrom<Option<{integer}>>` is not satisfi
   --> tests/ui/args_vec_mistakes.rs:22:36
    |
 22 | struct WrongCountType(#[br(count = Some(1))] Vec<u8>);
-   |                                    ^^^^^^^ the trait `From<Option<{integer}>>` is not implemented for `usize`, which is required by `usize: TryFrom<Option<{integer}>>`
+   |                                    ^^^^^^^ the trait `From<Option<{integer}>>` is not implemented for `usize`
    |
    = help: the following other types implement trait `From<T>`:
              `usize` implements `From<bool>`
@@ -82,7 +82,7 @@ error[E0277]: the trait bound `VecArgs<()>: Required` is not satisfied
   --> tests/ui/args_vec_mistakes.rs:28:5
    |
 28 |     Vec::<u8>::read(&mut binrw::io::Cursor::new(b"")).unwrap();
-   |     ^^^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`, which is required by `VecArgs<()>: Required`
+   |     ^^^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`
    |
    = note: required for `VecArgs<()>` to implement `Required`
 note: required by a bound in `binrw::BinRead::read`

--- a/binrw_derive/Cargo.toml
+++ b/binrw_derive/Cargo.toml
@@ -19,7 +19,7 @@ either = "1.0.0"
 owo-colors = { version = "3.0.0", optional = true }
 proc-macro2 = { version = "1.0.53", features = ["span-locations"] }
 quote = "1.0.0"
-syn = { version = "1.0.66", features = ["extra-traits", "fold", "full", "visit"] }
+syn = { version = "2", features = ["extra-traits", "fold", "full", "visit"] }
 
 [dev-dependencies]
 runtime-macros-derive = "0.4.0"

--- a/binrw_derive/Cargo.toml
+++ b/binrw_derive/Cargo.toml
@@ -22,7 +22,7 @@ quote = "1.0.0"
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit"] }
 
 [dev-dependencies]
-runtime-macros-derive = "0.4.0"
+runtime-macros = "1.1.0"
 
 [features]
 default = []

--- a/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
+++ b/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
@@ -7,7 +7,7 @@ use core::{
     ops::Range,
 };
 use owo_colors::{styles::BoldDisplay, XtermColors};
-use proc_macro2::{Span, TokenTree};
+use proc_macro2::Span;
 use quote::ToTokens;
 use std::collections::HashMap;
 use syn::{
@@ -135,13 +135,13 @@ fn highlight_attributes(attrs: &[syn::Attribute], visit: &mut Visitor) {
         // |____|______ path and pound_token
         //
         syntax_info.highlight_color(attr.pound_token.span(), Color::Keyword);
-        syntax_info.highlight_color(attr.path.span(), Color::Keyword);
+        syntax_info.highlight_color(attr.path().span(), Color::Keyword);
 
         // #[...]
         //  ^   ^
         //  |___|___ brackets
         //
-        let span = attr.bracket_token.span;
+        let span = attr.bracket_token.span.join();
         let start = start(span);
         let end = end(span);
 
@@ -158,9 +158,9 @@ fn highlight_attributes(attrs: &[syn::Attribute], visit: &mut Visitor) {
         //       ^   ^
         //       |___|___ parens
         //
-        if let Some(TokenTree::Group(group)) = attr.tokens.clone().into_iter().next() {
-            syntax_info.highlight_color(group.span_open(), Color::Keyword);
-            syntax_info.highlight_color(group.span_close(), Color::Keyword);
+        if let syn::Meta::List(l) = &attr.meta {
+            syntax_info.highlight_color(l.delimiter.span().open(), Color::Keyword);
+            syntax_info.highlight_color(l.delimiter.span().close(), Color::Keyword);
         }
     }
 }
@@ -291,7 +291,7 @@ impl<'ast> Visit<'ast> for Visitor {
                     Lit::Str(_) | Lit::ByteStr(_) => Color::String,
                     Lit::Byte(_) | Lit::Char(_) => Color::Char,
                     Lit::Int(_) | Lit::Float(_) | Lit::Bool(_) => Color::Number,
-                    Lit::Verbatim(_) => return,
+                    _ => return,
                 },
             ));
         }

--- a/binrw_derive/src/binrw/mod.rs
+++ b/binrw_derive/src/binrw/mod.rs
@@ -180,7 +180,7 @@ fn parse(
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[test]
 fn derive_binread_code_coverage_for_tool() {
-    use runtime_macros_derive::emulate_derive_expansion_fallible;
+    use runtime_macros::emulate_derive_macro_expansion;
     use std::{env, fs};
 
     let derive_tests_folder = env::current_dir()
@@ -195,16 +195,19 @@ fn derive_binread_code_coverage_for_tool() {
         let entry = entry.unwrap();
         if entry.file_type().unwrap().is_file() {
             let file = fs::File::open(entry.path()).unwrap();
-            if emulate_derive_expansion_fallible(file, "BinRead", |input| {
-                parse(
-                    &input,
-                    Options {
-                        derive: true,
-                        write: false,
-                    },
-                )
-                .1
-            })
+            if emulate_derive_macro_expansion(
+                file,
+                &[("BinRead", |input| {
+                    parse(
+                        &syn::parse2::<syn::DeriveInput>(input).unwrap(),
+                        Options {
+                            derive: true,
+                            write: false,
+                        },
+                    )
+                    .1
+                })],
+            )
             .is_err()
             {
                 run_success = false;
@@ -219,7 +222,7 @@ fn derive_binread_code_coverage_for_tool() {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[test]
 fn derive_binwrite_code_coverage_for_tool() {
-    use runtime_macros_derive::emulate_derive_expansion_fallible;
+    use runtime_macros::emulate_derive_macro_expansion;
     use std::{env, fs};
 
     let derive_tests_folder = env::current_dir()
@@ -235,16 +238,19 @@ fn derive_binwrite_code_coverage_for_tool() {
         let entry = entry.unwrap();
         if entry.file_type().unwrap().is_file() {
             let file = fs::File::open(entry.path()).unwrap();
-            if emulate_derive_expansion_fallible(file, "BinWrite", |input| {
-                parse(
-                    &input,
-                    Options {
-                        derive: true,
-                        write: true,
-                    },
-                )
-                .1
-            })
+            if emulate_derive_macro_expansion(
+                file,
+                &[("BinWrite", |input| {
+                    parse(
+                        &syn::parse2::<syn::DeriveInput>(input).unwrap(),
+                        Options {
+                            derive: true,
+                            write: true,
+                        },
+                    )
+                    .1
+                })],
+            )
             .is_err()
             {
                 run_success = false;

--- a/binrw_derive/src/binrw/mod.rs
+++ b/binrw_derive/src/binrw/mod.rs
@@ -87,14 +87,19 @@ pub(super) fn derive_from_attribute(
     let mut mixed_rw = false;
     let opposite_attr = if write { "binread" } else { "binwrite" };
     for attr in &mut derive_input.attrs {
-        if let Some(seg) = attr.path.segments.last() {
+        if let Some(seg) = attr.path().segments.last() {
             let ident = &seg.ident;
             if ident == "binrw" || ident == "binread" || ident == "binwrite" {
-                attr.tokens = quote! { (ignore) };
-
                 if ident == "binrw" || ident == opposite_attr {
                     mixed_rw = true;
                 }
+
+                let meta = syn::Meta::List(syn::MetaList {
+                    path: attr.path().clone(),
+                    delimiter: syn::MacroDelimiter::Paren(syn::token::Paren::default()),
+                    tokens: quote! { ignore },
+                });
+                attr.meta = meta;
             }
         }
     }
@@ -151,11 +156,11 @@ pub(super) fn derive_from_input(
 }
 
 fn is_binread_attr(attr: &syn::Attribute) -> bool {
-    attr.path.is_ident("br") || attr.path.is_ident("brw")
+    attr.path().is_ident("br") || attr.path().is_ident("brw")
 }
 
 fn is_binwrite_attr(attr: &syn::Attribute) -> bool {
-    attr.path.is_ident("bw") || attr.path.is_ident("brw")
+    attr.path().is_ident("bw") || attr.path().is_ident("brw")
 }
 
 fn parse(

--- a/binrw_derive/src/binrw/parser/field_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/field_level_attrs.rs
@@ -147,7 +147,7 @@ impl StructField {
 
         if self.do_try.is_some() && self.generated_value() {
             //TODO: join with span of read mode somehow
-            let span = self.do_try.as_ref().unwrap().span();
+            let span = self.do_try.as_ref().unwrap().span;
             combine_error(
                 &mut all_errors,
                 syn::Error::new(
@@ -176,14 +176,14 @@ impl StructField {
             let (span, repr) = match &self.args {
                 PassedArgs::Named(_) | PassedArgs::None => unreachable!(),
                 PassedArgs::List(list) => (
-                    list.span(),
+                    list.span,
                     format!(
                         "({},{})",
                         list.first().map_or_else(<_>::default, ToString::to_string),
                         if list.len() > 1 { " ..." } else { "" }
                     ),
                 ),
-                PassedArgs::Tuple(raw) => (raw.span(), raw.to_string()),
+                PassedArgs::Tuple(raw) => (raw.span, raw.to_string()),
             };
 
             for (used, name) in [

--- a/binrw_derive/src/binrw/parser/top_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/top_level_attrs.rs
@@ -383,7 +383,7 @@ impl<const WRITE: bool> FromInput<UnitEnumAttr<WRITE>> for UnitOnlyEnum {
 
     fn push_field(&mut self, field: Self::Field) -> syn::Result<()> {
         if let (Some(repr), Some(magic)) = (self.map.as_repr(), field.magic.as_ref()) {
-            let magic_span = magic.span();
+            let magic_span = magic.span;
             let span = magic_span.join(repr.span()).unwrap_or(magic_span);
             Err(syn::Error::new(
                 span,

--- a/binrw_derive/src/binrw/parser/types/magic.rs
+++ b/binrw_derive/src/binrw/parser/types/magic.rs
@@ -93,6 +93,7 @@ impl TryFrom<attrs::Magic> for SpannedValue<Inner> {
                     "expected byte string, byte, float, or int",
                 ))
             }
+            _ => return Err(syn::Error::new(value.span(), "unexpected literal")),
         };
 
         Ok(Self::new(

--- a/binrw_derive/src/binrw/parser/types/passed_args.rs
+++ b/binrw_derive/src/binrw/parser/types/passed_args.rs
@@ -24,8 +24,8 @@ impl PassedArgs {
     pub(crate) fn span(&self) -> Option<Span> {
         match self {
             PassedArgs::None => None,
-            PassedArgs::Tuple(s) => Some(s.span()),
-            PassedArgs::List(s) | PassedArgs::Named(s) => Some(s.span()),
+            PassedArgs::Tuple(s) => Some(s.span),
+            PassedArgs::List(s) | PassedArgs::Named(s) => Some(s.span),
         }
     }
 }

--- a/binrw_derive/src/binrw/parser/types/spanned_value.rs
+++ b/binrw_derive/src/binrw/parser/types/spanned_value.rs
@@ -4,7 +4,7 @@ use proc_macro2::Span;
 #[derive(Debug, Clone)]
 pub(crate) struct SpannedValue<T> {
     value: T,
-    span: Span,
+    pub span: Span,
 }
 
 impl<T> SpannedValue<T> {
@@ -29,14 +29,6 @@ impl<T> core::ops::Deref for SpannedValue<T> {
 
     fn deref(&self) -> &T {
         &self.value
-    }
-}
-
-// It is not possible to implement this *and* ToTokens because syn has a generic
-// implementation of Spanned for all ToTokens
-impl<T> syn::spanned::Spanned for SpannedValue<T> {
-    fn span(&self) -> Span {
-        self.span
     }
 }
 

--- a/binrw_derive/src/named_args/mod.rs
+++ b/binrw_derive/src/named_args/mod.rs
@@ -39,7 +39,11 @@ pub(crate) fn derive_from_imports(
         result_name,
         fields: &args.map(Into::into).collect::<Vec<_>>(),
         generics: lifetime
-            .map(|lifetime| [syn::GenericParam::Lifetime(syn::LifetimeDef::new(lifetime))])
+            .map(|lifetime| {
+                [syn::GenericParam::Lifetime(syn::LifetimeParam::new(
+                    lifetime,
+                ))]
+            })
             .as_ref()
             .map_or(&[], |generics| generics.as_slice()),
         vis,
@@ -60,7 +64,7 @@ fn from_input(input: DeriveInput) -> syn::Result<TokenStream> {
             .into_iter()
             .map(|field| {
                 let attrs = field.attrs.iter().filter_map(|attr| {
-                    attr.path
+                    attr.path()
                         .get_ident()
                         .filter(|ident| *ident == "named_args")
                         .map(|_| attr.parse_args::<NamedArgAttr>())
@@ -207,7 +211,7 @@ mod tests {
         }
     });
 
-    try_error!(missing_default_value: "expected expression" {
+    try_error!(missing_default_value: "unexpected end of input, expected an expression" {
         struct Foo<A> {
             #[named_args(default = )]
             a: A,

--- a/binrw_derive/src/named_args/mod.rs
+++ b/binrw_derive/src/named_args/mod.rs
@@ -153,9 +153,15 @@ mod kw {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[test]
 fn derive_named_args_code_coverage_for_tool() {
-    use runtime_macros_derive::emulate_derive_expansion_fallible;
+    use runtime_macros::emulate_derive_macro_expansion;
     let file = std::fs::File::open("../binrw/tests/named_args.rs").unwrap();
-    emulate_derive_expansion_fallible(file, "NamedArgs", |input| derive_from_input(input)).unwrap();
+    emulate_derive_macro_expansion(
+        file,
+        &[("NamedArgs", |input| {
+            derive_from_input(syn::parse2::<syn::DeriveInput>(input).unwrap())
+        })],
+    )
+    .unwrap();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As there were quite substantial changes from syn version 1 to 2 some minor changes to the codebase are necessary:

The `Attribute` type is more accurately typed now, that means instead of having simply a `Path` entity and some tokens after it, there is now a differentation between attributes with a `=`, in parentheses or without any other tokens but the path. This makes parsing slightly easier for us. Some test fixes were also required as these rely on the old tokens we got from an attribute.

The `Spanned` trait was sealed in syn v2. We implemented it for some of the internal meta types. As we still have the span information readily available and the trait is otherwise required nowhere, simply remove the impl.

Some syntax enums were marked as `non-exhaustive`. Handle these additional options in a sensible way where possible and throw compile errors in all other places.