### PR TITLE
Remove the 'static requirement from the BinRead Vec implementation by delegating to a new trait method.

### DIFF
--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -10,7 +10,9 @@ use core::num::{
 };
 
 macro_rules! binread_impl {
-    ($($type_name:ty),*$(,)?) => {
+    // `$(some_lit $(__unused $is_lit_present:tt))?` allows us to match on the present of a literal
+    // using `$($($is_list_present)? fn do_whatever() {})?`
+    ($($type_name:ty $(as int $(__unused $is_int:tt)?)?),*$(,)?) => {
         $(
             impl BinRead for $type_name {
                 type Args<'a> = ();
@@ -29,12 +31,122 @@ macro_rules! binread_impl {
                         }
                     })
                 }
+
+                $(
+                    $($is_int)?
+                    fn read_options_count<'a, R>(
+                        reader: &mut R,
+                        endian: Endian,
+                        _args: Self::Args<'a>,
+                        count: usize,
+                    ) -> BinResult<Vec<Self>>
+                    where
+                        R: Read + Seek,
+                        Self::Args<'a>: Clone,
+                    {
+                        let mut list = Vec::<Self>::new();
+                        let mut start = 0;
+                        let mut remaining = count;
+                        // Allocating and reading from the source in chunks is done to keep
+                        // a bad `count` from causing huge memory allocations that are
+                        // doomed to fail
+                        while remaining != 0 {
+                            // Using a similar strategy as std `default_read_to_end` to
+                            // leverage the memory growth strategy of the underlying Vec
+                            // implementation (in std this will be exponential) using a
+                            // minimum byte allocation
+                            let growth: usize = 32 / core::mem::size_of::<Self>();
+                            list.reserve(remaining.min(growth.max(1)));
+
+                            let items_to_read = remaining.min(list.capacity() - start);
+                            let end = start + items_to_read;
+
+                            // In benchmarks, this resize decreases performance by 27–40%
+                            // relative to using `unsafe` to write directly to uninitialised
+                            // memory, but nobody ever got fired for buying IBM
+                            list.resize(end, 0);
+                            reader.read_exact(&mut bytemuck::cast_slice_mut::<_, u8>(
+                                &mut list[start..end],
+                            ))?;
+
+                            remaining -= items_to_read;
+                            start += items_to_read;
+                        }
+
+                        if core::mem::size_of::<Self>() != 1
+                            && ((cfg!(target_endian = "big") && endian == crate::Endian::Little)
+                                || (cfg!(target_endian = "little") && endian == crate::Endian::Big))
+                        {
+                            for value in list.iter_mut() {
+                                *value = value.swap_bytes();
+                            }
+                        }
+                        Ok(list)
+                    }
+                )?
             }
         )*
     }
 }
 
-binread_impl!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);
+binread_impl!(
+    u16 as int,
+    u32 as int,
+    u64 as int,
+    u128 as int,
+    i8 as int,
+    i16 as int,
+    i32 as int,
+    i64 as int,
+    i128 as int,
+    f32,
+    f64
+);
+
+impl BinRead for u8 {
+    type Args<'a> = ();
+    fn read_options<R: Read + Seek>(
+        reader: &mut R,
+        _endian: Endian,
+        _args: Self::Args<'_>,
+    ) -> BinResult<Self> {
+        let mut val = 0u8;
+        let pos = reader.stream_position()?;
+        reader
+            .read_exact(core::slice::from_mut(&mut val))
+            .or_else(crate::__private::restore_position(reader, pos))?;
+
+        Ok(val)
+    }
+
+    // This extra impl for `u8` makes it faster than
+    // `binread_impl`, but *only* because `binread_impl` is not allowed
+    // to use unsafe code to eliminate the unnecessary zero-fill.
+    // Otherwise, performance would be identical and it could be
+    // deleted.
+    fn read_options_count<'a, R>(
+        reader: &mut R,
+        _endian: Endian,
+        _args: Self::Args<'a>,
+        count: usize,
+    ) -> BinResult<Vec<Self>>
+    where
+        R: Read + Seek,
+        Self::Args<'a>: Clone,
+    {
+        let mut container = Vec::<u8>::new();
+        container.reserve_exact(count);
+        let byte_count = reader
+            .take(count.try_into().map_err(crate::helpers::not_enough_bytes)?)
+            .read_to_end(&mut container)?;
+
+        if byte_count == count {
+            Ok(container)
+        } else {
+            Err(crate::helpers::not_enough_bytes(()))
+        }
+    }
+}
 
 fn unexpected_zero_num() -> Error {
     Error::Io(io::Error::new(
@@ -133,7 +245,7 @@ pub struct VecArgs<Inner: Clone> {
 
 impl<B> BinRead for Vec<B>
 where
-    B: BinRead + 'static,
+    B: BinRead,
     for<'a> B::Args<'a>: Clone,
 {
     type Args<'a> = VecArgs<B::Args<'a>>;
@@ -143,7 +255,7 @@ where
         endian: Endian,
         args: Self::Args<'_>,
     ) -> BinResult<Self> {
-        crate::helpers::count_with(args.count, B::read_options)(reader, endian, args.inner)
+        B::read_options_count(reader, endian, args.inner, args.count)
     }
 }
 

--- a/binrw/src/binread/mod.rs
+++ b/binrw/src/binread/mod.rs
@@ -192,6 +192,61 @@ pub trait BinRead: Sized {
         endian: Endian,
         args: Self::Args<'_>,
     ) -> BinResult<Self>;
+
+    /// Read `count` items of `Self` from the reader using the given [`Endian`] and arguments
+    ///
+    /// A vehicle for optimizations of types that can easily be read many-at-a-time.
+    /// For example, the integral types {i,u}{8,16,32,64,128}.
+    ///
+    /// # Errors
+    ///
+    /// If reading fails, an [`Error`](crate::Error) variant will be returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binrw::{io::{Read, Seek}, BinRead, BinResult, Endian};
+    /// struct CustomU8(u8);
+    ///
+    /// impl BinRead for CustomU8 {
+    ///     type Args<'a> = <u8 as BinRead>::Args<'a>;
+    ///
+    ///     fn read_options<R: Read + Seek>(
+    ///         reader: &mut R,
+    ///         endian: binrw::Endian,
+    ///         args: Self::Args<'_>,
+    ///     ) -> BinResult<Self> {
+    ///         u8::read_options(reader, endian, args).map(CustomU8)
+    ///     }
+    ///
+    ///     fn read_options_count<'a, R>(
+    ///         reader: &mut R,
+    ///         endian: Endian,
+    ///         args: Self::Args<'a>,
+    ///         count: usize,
+    ///     ) -> BinResult<Vec<Self>>
+    ///     where
+    ///         R: Read + Seek,
+    ///         Self::Args<'a>: Clone,
+    ///     {
+    ///         u8::read_options_count(reader, endian, args, count).map(|c| c.into_iter().map(CustomU8).collect())
+    ///     }
+    /// }
+    /// ```
+    fn read_options_count<'a, R>(
+        reader: &mut R,
+        endian: Endian,
+        args: Self::Args<'a>,
+        count: usize,
+    ) -> BinResult<Vec<Self>>
+    where
+        R: Read + Seek,
+        Self::Args<'a>: Clone,
+    {
+        core::iter::repeat_with(|| Self::read_options(reader, endian, args.clone()))
+            .take(count)
+            .collect()
+    }
 }
 
 /// Extension methods for reading [`BinRead`] objects directly from a reader.

--- a/binrw/tests/binread_impls.rs
+++ b/binrw/tests/binread_impls.rs
@@ -111,3 +111,23 @@ fn vec_u8() {
         binrw::Error::Io(..)
     ));
 }
+
+#[test]
+fn count_with_correctness() {
+    // This doesn't work for some reason, complains about specific lifetime versus any lifetime
+    //let read = |reader, _, _| u8::read(reader).map(|v| v & 0x0F);
+    fn weird_u8_read<R>(reader: &mut R, endian: binrw::Endian, args: ()) -> binrw::BinResult<u8>
+    where
+        R: binrw::io::Read + binrw::io::Seek,
+    {
+        u8::read(reader).map(|v| v & 0x0F)
+    }
+    let read = weird_u8_read;
+
+    let read = binrw::helpers::count_with(1, read);
+    let val: Vec<u8> = read(&mut Cursor::new(&[0xF3u8]), binrw::Endian::Little, ()).unwrap();
+    assert_eq!(
+        val[0], 0x03,
+        "binrw::helpers::count_with ignored the passed read function!"
+    )
+}


### PR DESCRIPTION
Fixes #298.

The core new API here is `BinRead::read_options_count`, where the implementation for `Vec<T>` will delegate to `T::read_options_count`. While I was implementing it, I noticed an inconsistency with the count_with helper, which can be fixed separately in another PR if this approach is rejected (or is taking a long time to solidify).

While I was at it, I decided to try applying the optimization to arrays, and got what is likely a functional result, but I'm not a big fan of it. Are there any tweaks we can make to the `read_options_count` signature to make the array implementation nicer? Do we want to keep the optimization for arrays, or do we want to keep it as it currently is?