### PR TITLE
Make count_with more consistent for builtin types.

### DIFF
--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -143,7 +143,7 @@ where
         endian: Endian,
         args: Self::Args<'_>,
     ) -> BinResult<Self> {
-        crate::helpers::count_with(args.count, B::read_options)(reader, endian, args.inner)
+        crate::helpers::count(args.count)(reader, endian, args.inner)
     }
 }
 

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -445,9 +445,9 @@ where
 /// # let x: CountBytes = x.read_be().unwrap();
 /// # assert_eq!(x.data, &[1, 2, 3]);
 /// ```
-pub fn count<R, T, Arg, Ret>(n: usize) -> impl Fn(&mut R, Endian, Arg) -> BinResult<Ret>
+pub fn count<'a, R, T, Arg, Ret>(n: usize) -> impl Fn(&mut R, Endian, Arg) -> BinResult<Ret>
 where
-    T: for<'a> BinRead<Args<'a> = Arg>,
+    T: BinRead<Args<'a> = Arg>,
     R: Read + Seek,
     Arg: Clone,
     Ret: FromIterator<T> + 'static,

--- a/binrw/tests/binread_impls.rs
+++ b/binrw/tests/binread_impls.rs
@@ -111,3 +111,14 @@ fn vec_u8() {
         binrw::Error::Io(..)
     ));
 }
+
+#[test]
+fn count_with_correctness() {
+    let read = binrw::helpers::count_with(2, binrw::helpers::read_u24);
+    let _: Vec<u32> = read(
+        &mut Cursor::new(&[0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF]),
+        binrw::Endian::Little,
+        (),
+    )
+    .expect("more than 3 bytes per u24 should not be required");
+}


### PR DESCRIPTION
Splitting this off from #317, as there's more solution space to sort through there, and I think fixing this is more important.

While writing this PR description, I thought of a less contrived example and test where this would break: reading 24 bit integers, which we already provide a helper for. `count_with(N, read_u24)` will currently read N u32s, instead of N u24s, and I have updated the test to reflect this.

The main thing I'm uncertain about here is the last commit, where I modify the API of `count` to make it callable from `Vec::read_options`. That may be a semver breakage, I'm not sure.

Before merging, I figure I'll do an interactive rebase to squash all of the commits prefixed with `fixup!`.