### PR TITLE
reduce copies of generic functions to improve compile times

### DIFF
--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -19,7 +19,7 @@ macro_rules! binread_impl {
                     let mut val = [0; core::mem::size_of::<$type_name>()];
                     let pos = reader.stream_position()?;
 
-                    reader.read_exact(&mut val).or_else(crate::__private::restore_position(reader, pos))?;
+                    reader.read_exact(&mut val).or_else(|e| Err(crate::__private::restore_position(reader, pos)(e)))?;
                     Ok(match endian {
                         Endian::Big => {
                             <$type_name>::from_be_bytes(val)

--- a/binrw/src/binread/impls.rs
+++ b/binrw/src/binread/impls.rs
@@ -19,7 +19,7 @@ macro_rules! binread_impl {
                     let mut val = [0; core::mem::size_of::<$type_name>()];
                     let pos = reader.stream_position()?;
 
-                    reader.read_exact(&mut val).or_else(|e| Err(crate::__private::restore_position(reader, pos)(e)))?;
+                    reader.read_exact(&mut val).map_err(crate::__private::restore_position(reader, pos))?;
                     Ok(match endian {
                         Endian::Big => {
                             <$type_name>::from_be_bytes(val)

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -612,43 +612,7 @@ fn not_enough_bytes<T>(_: T) -> Error {
 macro_rules! vec_fast_int {
     (try ($($Ty:ty)+) using ($list:expr, $reader:expr, $endian:expr, $count:expr) else { $($else:tt)* }) => {
         $(if let Some(list) = <dyn core::any::Any>::downcast_mut::<Vec<$Ty>>(&mut $list) {
-            let mut start = 0;
-            let mut remaining = $count;
-            // Allocating and reading from the source in chunks is done to keep
-            // a bad `count` from causing huge memory allocations that are
-            // doomed to fail
-            while remaining != 0 {
-                // Using a similar strategy as std `default_read_to_end` to
-                // leverage the memory growth strategy of the underlying Vec
-                // implementation (in std this will be exponential) using a
-                // minimum byte allocation
-                const GROWTH: usize = 32 / core::mem::size_of::<$Ty>();
-                list.reserve(remaining.min(GROWTH.max(1)));
-
-                let items_to_read = remaining.min(list.capacity() - start);
-                let end = start + items_to_read;
-
-                // In benchmarks, this resize decreases performance by 27–40%
-                // relative to using `unsafe` to write directly to uninitialised
-                // memory, but nobody ever got fired for buying IBM
-                list.resize(end, 0);
-                $reader.read_exact(&mut bytemuck::cast_slice_mut::<_, u8>(&mut list[start..end]))?;
-
-                remaining -= items_to_read;
-                start += items_to_read;
-            }
-
-            if
-                core::mem::size_of::<$Ty>() != 1
-                && (
-                    (cfg!(target_endian = "big") && $endian == crate::Endian::Little)
-                    || (cfg!(target_endian = "little") && $endian == crate::Endian::Big)
-                )
-            {
-                for value in list.iter_mut() {
-                    *value = value.swap_bytes();
-                }
-            }
+            read_vec_fast_int($reader, $count, $endian, list)?;
             Ok($list)
         } else)* {
             $($else)*
@@ -657,3 +621,69 @@ macro_rules! vec_fast_int {
 }
 
 use vec_fast_int;
+
+trait SwapBytes {
+    fn swap_bytes(self) -> Self;
+}
+
+macro_rules! swap_bytes_impl {
+    ($($ty:ty),*) => {
+        $(
+            impl SwapBytes for $ty {
+                fn swap_bytes(self) -> Self {
+                    <$ty>::swap_bytes(self)
+                }
+            }
+        )*
+    };
+}
+swap_bytes_impl!(i8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+fn read_vec_fast_int<T, R>(
+    reader: &mut R,
+    count: usize,
+    endian: Endian,
+    list: &mut Vec<T>,
+) -> BinResult<()>
+where
+    R: Read,
+    T: Clone + Default + bytemuck::Pod + SwapBytes,
+{
+    let mut start = 0;
+    let mut remaining = count;
+    // Allocating and reading from the source in chunks is done to keep
+    // a bad `count` from causing huge memory allocations that are
+    // doomed to fail
+    while remaining != 0 {
+        // Using a similar strategy as std `default_read_to_end` to
+        // leverage the memory growth strategy of the underlying Vec
+        // implementation (in std this will be exponential) using a
+        // minimum byte allocation
+        let growth = 32 / core::mem::size_of::<T>();
+        list.reserve(remaining.min(growth.max(1)));
+
+        let items_to_read = remaining.min(list.capacity() - start);
+        let end = start + items_to_read;
+
+        // In benchmarks, this resize decreases performance by 27–40%
+        // relative to using `unsafe` to write directly to uninitialised
+        // memory, but nobody ever got fired for buying IBM
+        list.resize(end, T::default());
+        reader.read_exact(&mut bytemuck::cast_slice_mut::<_, u8>(
+            &mut list[start..end],
+        ))?;
+
+        remaining -= items_to_read;
+        start += items_to_read;
+    }
+
+    if core::mem::size_of::<T>() != 1
+        && ((cfg!(target_endian = "big") && endian == crate::Endian::Little)
+            || (cfg!(target_endian = "little") && endian == crate::Endian::Big))
+    {
+        for value in list.iter_mut() {
+            *value = value.swap_bytes();
+        }
+    }
+    Ok(())
+}

--- a/binrw/src/helpers.rs
+++ b/binrw/src/helpers.rs
@@ -669,9 +669,7 @@ where
         // relative to using `unsafe` to write directly to uninitialised
         // memory, but nobody ever got fired for buying IBM
         list.resize(end, T::default());
-        reader.read_exact(&mut bytemuck::cast_slice_mut::<_, u8>(
-            &mut list[start..end],
-        ))?;
+        reader.read_exact(bytemuck::cast_slice_mut::<_, u8>(&mut list[start..end]))?;
 
         remaining -= items_to_read;
         start += items_to_read;

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -167,13 +167,13 @@ where
     args
 }
 
-pub fn restore_position<E: Into<Error>, S: Seek, T>(
+pub fn restore_position<E: Into<Error>, S: Seek>(
     stream: &mut S,
     pos: u64,
-) -> impl FnOnce(E) -> BinResult<T> + '_ {
+) -> impl FnOnce(E) -> Error + '_ {
     move |error| match stream.seek(SeekFrom::Start(pos)) {
-        Ok(_) => Err(error.into()),
-        Err(seek_error) => Err(restore_position_err(error.into(), seek_error.into())),
+        Ok(_) => error.into(),
+        Err(seek_error) => restore_position_err(error.into(), seek_error.into()),
     }
 }
 

--- a/binrw_derive/src/binrw/codegen/read_options.rs
+++ b/binrw_derive/src/binrw/codegen/read_options.rs
@@ -53,7 +53,7 @@ pub(crate) fn generate(input: &Input, derive_input: &syn::DeriveInput) -> TokenS
 
     let rewind = (needs_rewind || input.magic().is_some()).then(|| {
         quote! {
-            .or_else(|e| Err(#RESTORE_POSITION::<binrw::Error, _>(#reader_var, #POS)(e)))
+            .map_err(#RESTORE_POSITION::<binrw::Error, _>(#reader_var, #POS))
         }
     });
 

--- a/binrw_derive/src/binrw/codegen/read_options.rs
+++ b/binrw_derive/src/binrw/codegen/read_options.rs
@@ -53,7 +53,7 @@ pub(crate) fn generate(input: &Input, derive_input: &syn::DeriveInput) -> TokenS
 
     let rewind = (needs_rewind || input.magic().is_some()).then(|| {
         quote! {
-            .or_else(#RESTORE_POSITION::<binrw::Error, _, _>(#reader_var, #POS))
+            .or_else(|e| Err(#RESTORE_POSITION::<binrw::Error, _>(#reader_var, #POS)(e)))
         }
     });
 


### PR DESCRIPTION
I split out the fast int optimization into a generic function to reduce generated code as tested with cargo llvm-lines. This cuts compile times in release mode for building just the CLI on one of my projects in half. I was also able to reduce the copies of `binrw::__private::restore_position`, but that seems to make a measurable but not really noticeable difference.

0.14.1
```
  Lines                  Copies               Function name
  -----                  ------               -------------
  2363737                27552                (TOTAL)
   701044 (29.7%, 29.7%)   416 (1.5%,  1.5%)  binrw::helpers::count_with::{{closure}}
```
fork
```
  Lines                  Copies               Function name
  -----                  ------               -------------
  1915524                26572                (TOTAL)
   332052 (17.3%, 17.3%)   416 (1.6%,  1.6%)  binrw::helpers::count_with::{{closure}}
```
CLI code for reference:
<https://github.com/ScanMountGoat/xc3_lib/blob/88a2a635336d86062ce4db24022fa0cf956885d3/xc3_test>