### PR TITLE
Allow Args: Default to work in write derive with calc

### DIFF
--- a/binrw/tests/derive/write/struct_generic.rs
+++ b/binrw/tests/derive/write/struct_generic.rs
@@ -1,4 +1,6 @@
-use binrw::{io::Cursor, BinWrite};
+use std::marker::PhantomData;
+
+use binrw::{binwrite, io::Cursor, BinWrite};
 
 #[test]
 fn derive_allows_default() {
@@ -17,4 +19,25 @@ fn derive_allows_default() {
         .write_be(&mut Cursor::new(&mut result))
         .unwrap();
     assert_eq!(b"\0\0\x01", &result[..]);
+}
+
+#[test]
+fn derive_allows_calc_default() {
+    #[binwrite]
+    pub struct Test<T: BinWrite + Default>
+    where
+        for<'a> <T as BinWrite>::Args<'a>: Default,
+    {
+        #[bw(calc = T::default())]
+        a: T,
+        _phantom: PhantomData<T>,
+    }
+
+    let mut result = Vec::new();
+    Test::<u8> {
+        _phantom: PhantomData,
+    }
+    .write_be(&mut Cursor::new(&mut result))
+    .unwrap();
+    assert_eq!(b"\0", &result[..]);
 }

--- a/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
@@ -290,7 +290,7 @@ impl<'a> StructFieldGenerator<'a> {
                 }
             },
             FieldMode::Calc(_) | FieldMode::TryCalc(_) => quote! {
-                let #args = ();
+                let #args = <_ as #REQUIRED_ARG_TRAIT>::args();
                 #out
             },
             FieldMode::Function(_) => {


### PR DESCRIPTION
This fixes what I perceive to be an edge case left over from https://github.com/jam1garner/binrw/pull/226. Something to consider is if the args attribute is not allowed in combination with calc, does it make sense to allow generic args default to be used? Or is pinning the args type to the unit type intended for all generics used in calc fields? In the long run, I think it makes sense to allow args to be used with calc, but for now, this cleans up the bounds in my project.