### PR TITLE
Add serde-style `brw(bound)` attribute

### DIFF
--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -121,12 +121,8 @@ pub use binrw_derive::binrw;
 /// }
 ///
 /// #[binread]
-/// #[br(import_raw(args: GlobalArgs<T::Args<'_>>))]
-/// struct Container<T>
-/// where
-///     T: BinRead + 'static,
-///     for<'a> T::Args<'a>: Clone,
-/// {
+/// #[br(import_raw(args: GlobalArgs<T::Args<'_>>), bound(for<'a> T: BinRead + 'a, for<'a> <T as BinRead>::Args<'a>: Clone))]
+/// struct Container<T> {
 ///     #[br(temp, if(args.version > 1, 16))]
 ///     count: u16,
 ///     #[br(args {

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -7,8 +7,10 @@ use crate::{
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 pub use alloc::{boxed::Box, format, vec::Vec};
+#[cfg(not(feature = "std"))]
+pub use core::default::Default;
 #[cfg(feature = "std")]
-pub use std::{boxed::Box, format, vec::Vec};
+pub use std::{boxed::Box, default::Default, format, vec::Vec};
 
 pub use crate::named_args::{
     builder_helper, passthrough_helper, Needed, Optional, Satisfied, SatisfiedOrOptional,

--- a/binrw/tests/derive/struct_generic.rs
+++ b/binrw/tests/derive/struct_generic.rs
@@ -12,3 +12,16 @@ fn derive_generic() {
         <Test<u8> as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\0\x01\x02")).unwrap();
     t::assert_eq!(result.a, [0, 1, 2]);
 }
+
+#[test]
+fn derive_generic_bound() {
+    #[derive(binrw::BinRead)]
+    #[br(bound(T: for<'a> binrw::BinRead<Args<'a> = ()> + t::Default))]
+    struct Test<T> {
+        a: [T; 3],
+    }
+
+    let result =
+        <Test<u8> as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\0\x01\x02")).unwrap();
+    t::assert_eq!(result.a, [0, 1, 2]);
+}

--- a/binrw/tests/derive/struct_generic.rs
+++ b/binrw/tests/derive/struct_generic.rs
@@ -16,7 +16,7 @@ fn derive_generic() {
 #[test]
 fn derive_generic_bound() {
     #[derive(binrw::BinRead)]
-    #[br(bound(T: for<'a> binrw::BinRead<Args<'a> = ()> + t::Default))]
+    #[br(bound(T: for<'a> binrw::BinRead<Args<'a> = ()>))]
     struct Test<T> {
         a: [T; 3],
     }

--- a/binrw/tests/derive/write/struct_generic.rs
+++ b/binrw/tests/derive/write/struct_generic.rs
@@ -21,3 +21,20 @@ fn derive_allows_default() {
     .unwrap();
     t::assert_eq!(b"\0\0\x01", &result[..]);
 }
+
+#[test]
+fn derive_generic_bound() {
+    #[derive(binrw::BinWrite)]
+    #[bw(bound(for<'a> T: binrw::BinWrite + 'a, for<'a> T::Args<'a>: t::Default + t::Clone))]
+    struct Test<T> {
+        a: [T; 3],
+    }
+
+    let mut result = t::Vec::new();
+    binrw::BinWrite::write_le(
+        &Test::<u8> { a: [0, 1, 2] },
+        &mut binrw::io::Cursor::new(&mut result),
+    )
+    .unwrap();
+    t::assert_eq!(b"\0\x01\x02", &result[..]);
+}

--- a/binrw/tests/ui/invalid_keyword_enum.stderr
+++ b/binrw/tests/ui/invalid_keyword_enum.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `return_all_errors`, `return_unexpected_error`
+error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `return_all_errors`, `return_unexpected_error`, `bound`
  --> tests/ui/invalid_keyword_enum.rs:4:6
   |
 4 | #[br(invalid_enum_keyword)]

--- a/binrw/tests/ui/invalid_keyword_enum_variant.stderr
+++ b/binrw/tests/ui/invalid_keyword_enum_variant.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `bound`
  --> tests/ui/invalid_keyword_enum_variant.rs:5:10
   |
 5 |     #[br(invalid_enum_variant_keyword)]

--- a/binrw/tests/ui/invalid_keyword_struct.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `bound`
  --> tests/ui/invalid_keyword_struct.rs:4:6
   |
 4 | #[br(invalid_struct_keyword)]

--- a/binrw/tests/ui/invalid_keyword_with_imports.stderr
+++ b/binrw/tests/ui/invalid_keyword_with_imports.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `bound`
  --> tests/ui/invalid_keyword_with_imports.rs:5:6
   |
 5 | #[br(invalid_struct_keyword)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`
+error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `import`, `import_raw`, `assert`, `pre_assert`, `bound`
  --> tests/ui/non_blocking_errors.rs:6:6
   |
 6 | #[br(invalid_keyword_struct)]

--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -17,7 +17,7 @@ use sanitization::{
     BIN_ERROR, BIN_RESULT, BOX, ENDIAN_ENUM, FORMAT, OPT, POS, READER, READ_TRAIT, SEEK_TRAIT,
     TEMP, WRITER, WRITE_TRAIT,
 };
-use syn::{spanned::Spanned, DeriveInput, Ident, Type};
+use syn::{spanned::Spanned, DeriveInput, Ident, Token, Type, WhereClause};
 
 pub(crate) fn generate_impl<const WRITE: bool>(
     derive_input: &DeriveInput,
@@ -164,23 +164,31 @@ fn generate_trait_impl<const WRITE: bool>(
         )
     };
 
-    let fn_impl = match binrw_input {
+    let name = &derive_input.ident;
+    let (impl_generics, ty_generics, where_clause) = derive_input.generics.split_for_impl();
+
+    let (fn_impl, where_clause) = match binrw_input {
         ParseResult::Ok(binrw_input) => {
             if WRITE {
-                write_options::generate(binrw_input, derive_input)
+                (
+                    write_options::generate(binrw_input, derive_input),
+                    get_where_clause(binrw_input, where_clause),
+                )
             } else {
-                read_options::generate(binrw_input, derive_input)
+                (
+                    read_options::generate(binrw_input, derive_input),
+                    get_where_clause(binrw_input, where_clause),
+                )
             }
         }
         // If there is a parsing error, an impl for the trait still needs to be
         // generated to avoid misleading errors at all call sites that use the
         // trait, so emit the trait and just stick the errors inside the generated
         // function
-        ParseResult::Partial(_, error) | ParseResult::Err(error) => error.to_compile_error(),
+        ParseResult::Partial(_, error) | ParseResult::Err(error) => {
+            (error.to_compile_error(), where_clause.cloned())
+        }
     };
-
-    let name = &derive_input.ident;
-    let (impl_generics, ty_generics, where_clause) = derive_input.generics.split_for_impl();
 
     let args_lifetime = get_args_lifetime(Span::call_site());
     quote! {
@@ -193,6 +201,25 @@ fn generate_trait_impl<const WRITE: bool>(
             #fn_sig {
                 #fn_impl
             }
+        }
+    }
+}
+
+fn get_where_clause(
+    binrw_input: &Input,
+    where_clause: Option<&WhereClause>,
+) -> Option<WhereClause> {
+    match (binrw_input.bound(), where_clause) {
+        (None, where_clause) => where_clause.cloned(),
+        (Some(bound), where_clause) if bound.predicates().is_empty() => where_clause.cloned(),
+        (Some(bound), None) => Some(WhereClause {
+            where_token: Token![where](Span::call_site()),
+            predicates: bound.predicates().clone(),
+        }),
+        (Some(bound), Some(where_clause)) => {
+            let mut where_clause = where_clause.clone();
+            where_clause.predicates.extend(bound.predicates().clone());
+            Some(where_clause)
         }
     }
 }

--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -3,11 +3,11 @@ mod read_options;
 pub(crate) mod sanitization;
 mod write_options;
 
-use std::collections::HashSet;
+use std::borrow::Cow;
 
 use crate::{
     binrw::parser::{
-        Assert, AssertionError, CondEndian, Imports, Input, ParseResult, PassedArgs, Struct,
+        Assert, AssertionError, Bound, CondEndian, Imports, Input, ParseResult, PassedArgs,
         StructField,
     },
     named_args::{arg_type_name, derive_from_imports},
@@ -17,12 +17,10 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use sanitization::{
     ARGS, ARGS_LIFETIME, ARGS_MACRO, ASSERT, ASSERT_ERROR_FN, BINREAD_TRAIT, BINWRITE_TRAIT,
-    BIN_ERROR, BIN_RESULT, BOX, ENDIAN_ENUM, FORMAT, OPT, POS, READER, READ_TRAIT, SEEK_TRAIT,
-    TEMP, WRITER, WRITE_TRAIT,
+    BIN_ERROR, BIN_RESULT, BOX, DEFAULT, ENDIAN_ENUM, FORMAT, OPT, POS, READER, READ_TRAIT,
+    SEEK_TRAIT, TEMP, WRITER, WRITE_TRAIT,
 };
 use syn::{parse_quote, spanned::Spanned, DeriveInput, Ident, Type};
-
-use super::parser::{EnumVariant, FieldMode};
 
 pub(crate) fn generate_impl<const WRITE: bool>(
     derive_input: &DeriveInput,
@@ -182,9 +180,10 @@ fn generate_trait_impl<const WRITE: bool>(
         // generated to avoid misleading errors at all call sites that use the
         // trait, so emit the trait and just stick the errors inside the generated
         // function
-        ParseResult::Partial(_, error) | ParseResult::Err(error) => {
-            (error.to_compile_error(), derive_input.generics.clone())
-        }
+        ParseResult::Partial(_, error) | ParseResult::Err(error) => (
+            error.to_compile_error(),
+            Cow::Borrowed(&derive_input.generics),
+        ),
     };
 
     let name = &derive_input.ident;
@@ -205,229 +204,51 @@ fn generate_trait_impl<const WRITE: bool>(
     }
 }
 
-fn get_generics<const WRITE: bool>(binrw_input: &Input, generics: &syn::Generics) -> syn::Generics {
-    match binrw_input.bound() {
-        None => get_inferred_generics::<WRITE>(binrw_input, generics),
-        Some(bound) => {
-            let mut generics = generics.clone();
-            generics
-                .make_where_clause()
-                .predicates
-                .extend(bound.predicates().iter().cloned());
-            generics
-        }
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-fn get_inferred_generics<const WRITE: bool>(
+fn get_generics<'a, const WRITE: bool>(
     binrw_input: &Input,
-    generics: &syn::Generics,
-) -> syn::Generics {
-    // AST visitor adapted from serde
-    // https://github.com/serde-rs/serde/blob/b9de3658ad9ca7850c496e0f990d5241b943eefb/serde_derive/src/bound.rs#L91
-    struct FindTyParams<'ast> {
-        all_type_params: HashSet<syn::Ident>,
-        relevant_type_params: HashSet<syn::Ident>,
-        associated_type_usage: Vec<&'ast syn::TypePath>,
+    generics: &'a syn::Generics,
+) -> Cow<'a, syn::Generics> {
+    match binrw_input.bound() {
+        Some(Bound::Implicit(type_paths)) => {
+            if type_paths.is_empty() {
+                Cow::Borrowed(generics)
+            } else {
+                let mut generics = generics.clone();
+                generics
+                    .make_where_clause()
+                    .predicates
+                    .extend(type_paths.iter().flat_map(|bounded_ty| {
+                        let args_lifetime = get_args_lifetime(Span::call_site());
+
+                        let binrw_bound = if WRITE { BINWRITE_TRAIT } else { BINREAD_TRAIT };
+
+                        let where_predicates: syn::punctuated::Punctuated<
+                            syn::WherePredicate,
+                            syn::Token![,],
+                        > = parse_quote! {
+                            for<#args_lifetime> #bounded_ty: #binrw_bound + #args_lifetime,
+                            for<#args_lifetime> <#bounded_ty as #binrw_bound>::Args<#args_lifetime>: #DEFAULT,
+                        };
+
+                        where_predicates
+                    }));
+                Cow::Owned(generics)
+            }
+        }
+        Some(Bound::Explicit(where_predicates)) => {
+            if where_predicates.is_empty() {
+                Cow::Borrowed(generics)
+            } else {
+                let mut generics = generics.clone();
+                generics
+                    .make_where_clause()
+                    .predicates
+                    .extend(where_predicates.iter().cloned());
+                Cow::Owned(generics)
+            }
+        }
+        None => Cow::Borrowed(generics),
     }
-
-    pub fn ungroup(mut ty: &Type) -> &Type {
-        while let Type::Group(group) = ty {
-            ty = &group.elem;
-        }
-        ty
-    }
-
-    impl<'ast> FindTyParams<'ast> {
-        fn new(generics: &syn::Generics) -> Self {
-            Self {
-                all_type_params: generics
-                    .type_params()
-                    .map(|param| param.ident.clone())
-                    .collect(),
-                relevant_type_params: HashSet::new(),
-                associated_type_usage: Vec::new(),
-            }
-        }
-
-        fn visit_field(&mut self, field: &'ast syn::Field) {
-            if let syn::Type::Path(ty) = ungroup(&field.ty) {
-                if let Some(syn::punctuated::Pair::Punctuated(t, _)) =
-                    ty.path.segments.pairs().next()
-                {
-                    if self.all_type_params.contains(&t.ident) {
-                        self.associated_type_usage.push(ty);
-                    }
-                }
-            }
-            self.visit_type(&field.ty);
-        }
-
-        fn visit_path(&mut self, path: &'ast syn::Path) {
-            if let Some(seg) = path.segments.last() {
-                // We know PhantomData<T> will always impl BinRead/BinWrite so
-                // we don't count this T as a relevant type param.
-                if seg.ident == "PhantomData" {
-                    return;
-                }
-            }
-            if path.leading_colon.is_none() && path.segments.len() == 1 {
-                let id = &path.segments[0].ident;
-                if self.all_type_params.contains(id) {
-                    self.relevant_type_params.insert(id.clone());
-                }
-            }
-            for segment in &path.segments {
-                self.visit_path_segment(segment);
-            }
-        }
-
-        fn visit_type(&mut self, ty: &'ast syn::Type) {
-            match ty {
-                syn::Type::Array(ty) => self.visit_type(&ty.elem),
-                syn::Type::BareFn(ty) => {
-                    for arg in &ty.inputs {
-                        self.visit_type(&arg.ty);
-                    }
-                    self.visit_return_type(&ty.output);
-                }
-                syn::Type::Group(ty) => self.visit_type(&ty.elem),
-                syn::Type::ImplTrait(ty) => {
-                    for bound in &ty.bounds {
-                        self.visit_type_param_bound(bound);
-                    }
-                }
-                syn::Type::Paren(ty) => self.visit_type(&ty.elem),
-                syn::Type::Path(ty) => {
-                    if let Some(qself) = &ty.qself {
-                        self.visit_type(&qself.ty);
-                    }
-                    self.visit_path(&ty.path);
-                }
-                syn::Type::Ptr(ty) => self.visit_type(&ty.elem),
-                syn::Type::Reference(ty) => self.visit_type(&ty.elem),
-                syn::Type::Slice(ty) => self.visit_type(&ty.elem),
-                syn::Type::TraitObject(ty) => {
-                    for bound in &ty.bounds {
-                        self.visit_type_param_bound(bound);
-                    }
-                }
-                syn::Type::Tuple(ty) => {
-                    for elem in &ty.elems {
-                        self.visit_type(elem);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        fn visit_path_segment(&mut self, segment: &'ast syn::PathSegment) {
-            self.visit_path_arguments(&segment.arguments);
-        }
-
-        fn visit_path_arguments(&mut self, arguments: &'ast syn::PathArguments) {
-            match arguments {
-                syn::PathArguments::None => {}
-                syn::PathArguments::AngleBracketed(arguments) => {
-                    for arg in &arguments.args {
-                        match arg {
-                            syn::GenericArgument::Type(arg) => self.visit_type(arg),
-                            syn::GenericArgument::AssocType(arg) => self.visit_type(&arg.ty),
-                            _ => {}
-                        }
-                    }
-                }
-                syn::PathArguments::Parenthesized(arguments) => {
-                    for argument in &arguments.inputs {
-                        self.visit_type(argument);
-                    }
-                    self.visit_return_type(&arguments.output);
-                }
-            }
-        }
-
-        fn visit_return_type(&mut self, return_type: &'ast syn::ReturnType) {
-            match return_type {
-                syn::ReturnType::Default => {}
-                syn::ReturnType::Type(_, output) => self.visit_type(output),
-            }
-        }
-
-        fn visit_type_param_bound(&mut self, bound: &'ast syn::TypeParamBound) {
-            if let syn::TypeParamBound::Trait(bound) = bound {
-                self.visit_path(&bound.path);
-            }
-        }
-    }
-
-    let mut visitor = FindTyParams::new(generics);
-
-    let should_visit = if WRITE {
-        |_: &Struct, f: &StructField| !matches!(&f.field_mode, FieldMode::Function(_))
-    } else {
-        |s: &Struct, f: &StructField| {
-            matches!(&f.field_mode, FieldMode::Normal) && f.map.is_none() && s.map.is_none()
-        }
-    };
-
-    match binrw_input {
-        Input::Struct(s) | Input::UnitStruct(s) => {
-            for field in s.fields.iter().filter(|f| should_visit(s, f)) {
-                visitor.visit_field(&field.field);
-            }
-        }
-        Input::Enum(e) => {
-            for variant in &e.variants {
-                match variant {
-                    EnumVariant::Variant { options, .. } => {
-                        let relevant_fields =
-                            options.fields.iter().filter(|f| should_visit(options, f));
-                        for field in relevant_fields {
-                            visitor.visit_field(&field.field);
-                        }
-                    }
-                    EnumVariant::Unit(_) => {}
-                }
-            }
-        }
-        Input::UnitOnlyEnum(_) => {}
-    }
-
-    let relevant_type_params = visitor.relevant_type_params;
-    let associated_type_usage = visitor.associated_type_usage;
-    let new_predicates =
-        generics
-            .type_params()
-            .map(|param| param.ident.clone())
-            .filter(|ident| relevant_type_params.contains(ident))
-            .map(|ident| syn::TypePath {
-                qself: None,
-                path: ident.into(),
-            })
-            .chain(associated_type_usage.into_iter().cloned())
-            .flat_map(|bounded_ty| {
-                let args_lifetime = get_args_lifetime(Span::call_site());
-
-                let binrw_bound = if WRITE { BINWRITE_TRAIT } else { BINREAD_TRAIT };
-
-                let where_predicates: syn::punctuated::Punctuated<
-                    syn::WherePredicate,
-                    syn::Token![,],
-                > = parse_quote! {
-                    for<#args_lifetime> #bounded_ty: #binrw_bound + #args_lifetime,
-                    for<#args_lifetime> #bounded_ty::Args<#args_lifetime>: ::core::default::Default,
-                };
-
-                where_predicates
-            });
-
-    let mut generics = generics.clone();
-    generics
-        .make_where_clause()
-        .predicates
-        .extend(new_predicates);
-    generics
 }
 
 fn get_args_lifetime(span: proc_macro2::Span) -> syn::Lifetime {

--- a/binrw_derive/src/binrw/codegen/sanitization.rs
+++ b/binrw_derive/src/binrw/codegen/sanitization.rs
@@ -80,6 +80,7 @@ ident_str! {
     pub(crate) DBG_EPRINTLN = from_crate!(__private::eprintln);
     pub(crate) FORMAT = from_crate!(__private::format);
     pub(crate) VEC = from_crate!(__private::Vec);
+    pub(crate) DEFAULT = from_crate!(__private::Default);
 }
 
 pub(crate) fn make_ident(ident: &Ident, kind: &str) -> Ident {

--- a/binrw_derive/src/binrw/parser/attrs.rs
+++ b/binrw_derive/src/binrw/parser/attrs.rs
@@ -3,7 +3,7 @@ use crate::meta_types::{
     IdentPatType, IdentTypeMaybeDefault, MetaEnclosedList, MetaExpr, MetaIdent, MetaList, MetaLit,
     MetaType, MetaValue, MetaVoid,
 };
-use syn::{Expr, FieldValue, Token};
+use syn::{Expr, FieldValue, Token, WherePredicate};
 
 pub(super) type AlignAfter = MetaExpr<kw::align_after>;
 pub(super) type AlignBefore = MetaExpr<kw::align_before>;
@@ -12,6 +12,7 @@ pub(super) type ArgsRaw = MetaExpr<kw::args_raw>;
 pub(super) type AssertLike<Keyword> = MetaList<Keyword, Expr>;
 pub(super) type Assert = AssertLike<kw::assert>;
 pub(super) type Big = MetaVoid<kw::big>;
+pub(super) type Bound = MetaList<kw::bound, WherePredicate>;
 pub(super) type Calc = MetaExpr<kw::calc>;
 pub(super) type Count = MetaExpr<kw::count>;
 pub(super) type Debug = MetaVoid<kw::dbg>;

--- a/binrw_derive/src/binrw/parser/keywords.rs
+++ b/binrw_derive/src/binrw/parser/keywords.rs
@@ -17,6 +17,7 @@ define_keywords! {
     br,
     brw,
     binwrite,
+    bound,
     bw,
     calc,
     count,

--- a/binrw_derive/src/binrw/parser/top_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/top_level_attrs.rs
@@ -1,7 +1,7 @@
 use super::{
     attr_struct,
     types::{Assert, CondEndian, EnumErrorMode, Imports, Magic, Map},
-    EnumVariant, FromInput, ParseResult, StructField, TrySet, UnitEnumField,
+    Bound, EnumVariant, FromInput, ParseResult, StructField, TrySet, UnitEnumField,
 };
 use crate::binrw::Options;
 use proc_macro2::TokenStream;
@@ -175,6 +175,14 @@ impl Input {
         }
     }
 
+    pub(crate) fn bound(&self) -> &Bound {
+        match self {
+            Input::Struct(s) | Input::UnitStruct(s) => &s.bound,
+            Input::Enum(e) => &e.bound,
+            Input::UnitOnlyEnum(_) => &None,
+        }
+    }
+
     pub(crate) fn stream_ident(&self) -> Option<&Ident> {
         match self {
             Input::Struct(s) | Input::UnitStruct(s) => s.stream_ident.as_ref(),
@@ -217,6 +225,8 @@ attr_struct! {
         pub(crate) assertions: Vec<Assert>,
         #[from(RO:PreAssert)]
         pub(crate) pre_assertions: Vec<Assert>,
+        #[from(RW:Bound)]
+        pub(crate) bound: Bound,
         pub(crate) fields: Vec<StructField>,
         pub(crate) for_write: bool,
     }
@@ -327,6 +337,8 @@ attr_struct! {
         pub(crate) pre_assertions: Vec<Assert>,
         #[from(RO:ReturnAllErrors, RO:ReturnUnexpectedError)]
         pub(crate) error_mode: EnumErrorMode,
+        #[from(RW:Bound)]
+        pub(crate) bound: Bound,
         pub(crate) variants: Vec<EnumVariant>,
     }
 }

--- a/binrw_derive/src/binrw/parser/types/bound.rs
+++ b/binrw_derive/src/binrw/parser/types/bound.rs
@@ -1,0 +1,24 @@
+use crate::{binrw::parser::attrs, meta_types::KeywordToken};
+use syn::{punctuated::Punctuated, Token, WherePredicate};
+
+use super::SpannedValue;
+
+pub(crate) type Bound = Option<SpannedValue<Inner>>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Inner(Punctuated<WherePredicate, Token![,]>);
+
+impl Inner {
+    pub(crate) fn predicates(&self) -> &Punctuated<WherePredicate, Token![,]> {
+        &self.0
+    }
+}
+
+impl TryFrom<attrs::Bound> for SpannedValue<Inner> {
+    type Error = syn::Error;
+
+    fn try_from(bound: attrs::Bound) -> Result<Self, Self::Error> {
+        let kw_span = bound.keyword_span();
+        Ok(Self::new(Inner(bound.fields), kw_span))
+    }
+}

--- a/binrw_derive/src/binrw/parser/types/mod.rs
+++ b/binrw_derive/src/binrw/parser/types/mod.rs
@@ -1,4 +1,5 @@
 mod assert;
+mod bound;
 mod cond_endian;
 mod condition;
 mod enum_error_mode;
@@ -11,6 +12,7 @@ mod passed_args;
 mod spanned_value;
 
 pub(crate) use assert::{Assert, Error as AssertionError};
+pub(crate) use bound::Bound;
 pub(crate) use cond_endian::CondEndian;
 pub(crate) use condition::Condition;
 pub(crate) use enum_error_mode::EnumErrorMode;


### PR DESCRIPTION
This PR adds a [serde-style `brw(bound)` attribute](https://serde.rs/container-attrs.html#bound). Serde also has a page further describing when this is useful: https://serde.rs/attr-bound.html. I brought this up in the Discord the other day and decided to quickly implement it as a proof of concept to better explain my thinking.

This is only a draft because I still have some unanswered questions. First, it doesn't really make sense for this attribute to be allowed on unit structs since they cannot have generic parameters, but struct and unit struct share the same Attr struct, unlike enum and unit only enum. Should I split this into two Attr structs? Is bound the only attribute that would be on struct and not unit struct, or should any other attributes be removed from the unit struct Attr struct after the split?

Second, right now, there are no default bounds added if the bound attribute is not present. I am worried that adding default inferred bounds will break existing code or complicate the implementation.

Finally, I'll wait to add more tests and docs until we have settled on the details.