### PR TITLE
Fix `map` + `write_with` and `type_hint` functions lifetimes

### DIFF
--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -212,14 +212,14 @@ pub fn restore_position_variant<S: Seek>(
     }
 }
 
-pub fn write_try_map_args_type_hint<Input, Output, Error, MapFn, Args>(
+pub fn write_try_map_args_type_hint<'a, Input, Output, Error, MapFn, Args>(
     _: &MapFn,
     args: Args,
 ) -> Args
 where
     Error: CustomError,
     MapFn: FnOnce(Input) -> Result<Output, Error>,
-    Output: for<'a> BinWrite<Args<'a> = Args>,
+    Output: BinWrite<Args<'a> = Args>,
 {
     args
 }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -133,10 +133,10 @@ where
     a
 }
 
-pub fn map_args_type_hint<Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
+pub fn map_args_type_hint<'a, Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
 where
     MapFn: FnOnce(Input) -> Output,
-    Input: for<'a> BinRead<Args<'a> = Args>,
+    Input: BinRead<Args<'a> = Args>,
 {
     args
 }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -125,10 +125,10 @@ where
     a
 }
 
-pub fn write_function_args_type_hint<T, W, Args, F>(_: &F, a: Args) -> Args
+pub fn write_function_args_type_hint<'a, T, W, Args, F>(_: &F, a: Args) -> Args
 where
     W: Write + Seek,
-    F: FnOnce(&T, &mut W, Endian, Args) -> BinResult<()>,
+    F: FnOnce(&'a T, &mut W, Endian, Args) -> BinResult<()>,
 {
     a
 }
@@ -159,10 +159,10 @@ where
     x
 }
 
-pub fn write_fn_type_hint<T, WriterFn, Writer, Args>(x: WriterFn) -> WriterFn
+pub fn write_fn_type_hint<'a, T, WriterFn, Writer, Args>(x: WriterFn) -> WriterFn
 where
     Writer: Write + Seek,
-    WriterFn: FnOnce(&T, &mut Writer, Endian, Args) -> BinResult<()>,
+    WriterFn: FnOnce(&'a T, &mut Writer, Endian, Args) -> BinResult<()>,
 {
     x
 }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -167,10 +167,10 @@ where
     x
 }
 
-pub fn write_map_args_type_hint<Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
+pub fn write_map_args_type_hint<'a, Input, Output, MapFn, Args>(_: &MapFn, args: Args) -> Args
 where
     MapFn: FnOnce(Input) -> Output,
-    Output: for<'a> BinWrite<Args<'a> = Args>,
+    Output: BinWrite<Args<'a> = Args>,
 {
     args
 }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -244,7 +244,7 @@ where
     func
 }
 
-pub fn write_fn_try_map_output_type_hint<Input, Output, Error, MapFn, Writer, WriteFn, Args>(
+pub fn write_fn_try_map_output_type_hint<'a, Input, Output, Error, MapFn, Writer, WriteFn, Args>(
     _: &MapFn,
     func: WriteFn,
 ) -> WriteFn
@@ -253,7 +253,7 @@ where
     MapFn: FnOnce(Input) -> Result<Output, Error>,
     Args: Clone,
     Writer: Write + Seek,
-    WriteFn: Fn(&Output, &mut Writer, Endian, Args) -> BinResult<()>,
+    WriteFn: Fn(&'a Output, &mut Writer, Endian, Args) -> BinResult<()>,
 {
     func
 }

--- a/binrw/src/private.rs
+++ b/binrw/src/private.rs
@@ -231,7 +231,7 @@ where
     func
 }
 
-pub fn write_fn_map_output_type_hint<Input, Output, MapFn, Writer, WriteFn, Args>(
+pub fn write_fn_map_output_type_hint<'a, Input, Output, MapFn, Writer, WriteFn, Args>(
     _: &MapFn,
     func: WriteFn,
 ) -> WriteFn
@@ -239,7 +239,7 @@ where
     MapFn: FnOnce(Input) -> Output,
     Args: Clone,
     Writer: Write + Seek,
-    WriteFn: Fn(&Output, &mut Writer, Endian, Args) -> BinResult<()>,
+    WriteFn: Fn(&'a Output, &mut Writer, Endian, Args) -> BinResult<()>,
 {
     func
 }

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -454,6 +454,25 @@ fn gat_raw() {
 }
 
 #[test]
+fn gat_map() {
+    #[derive(BinRead)]
+    #[br(import(borrowed: &u8))]
+    struct Wrapper(#[br(calc = *borrowed)] u8);
+
+    #[derive(BinRead, Debug, PartialEq)]
+    #[br(little, import(borrowed: &u8))]
+    struct Test {
+        #[br(map = |x: Wrapper| x.0, args(borrowed))]
+        a: u8,
+    }
+
+    assert_eq!(
+        Test::read_args(&mut Cursor::new(b""), (&1_u8,)).unwrap(),
+        Test { a: 1 }
+    );
+}
+
+#[test]
 fn if_alternate() {
     #[derive(BinRead, Debug)]
     #[br(import{ try_read: bool })]

--- a/binrw/tests/derive/write/custom_writer.rs
+++ b/binrw/tests/derive/write/custom_writer.rs
@@ -79,3 +79,22 @@ fn map_write_with_as_ref_str() {
     MyType { value: 42 }.write_le(&mut x).unwrap();
     assert_eq!(x.into_inner(), b"42");
 }
+
+#[test]
+fn try_map_write_with_as_ref_str() {
+    use binrw::prelude::*;
+
+    #[derive(BinWrite)]
+    struct MyType<'a> {
+        #[bw(try_map = |x| x.ok_or("Option was None"), write_with = write_as_ref_str)]
+        value: Option<&'a str>,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    MyType {
+        value: Some("Hello, World!"),
+    }
+    .write_le(&mut x)
+    .unwrap();
+    assert_eq!(x.into_inner(), b"Hello, World!");
+}

--- a/binrw/tests/derive/write/custom_writer.rs
+++ b/binrw/tests/derive/write/custom_writer.rs
@@ -64,3 +64,18 @@ fn write_with_as_ref_str() {
     .unwrap();
     assert_eq!(x.into_inner(), b"Hello, World!");
 }
+
+#[test]
+fn map_write_with_as_ref_str() {
+    use binrw::prelude::*;
+
+    #[derive(BinWrite)]
+    struct MyType {
+        #[bw(map = |x| x.to_string(), write_with = write_as_ref_str)]
+        value: u32,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    MyType { value: 42 }.write_le(&mut x).unwrap();
+    assert_eq!(x.into_inner(), b"42");
+}

--- a/binrw/tests/derive/write/custom_writer.rs
+++ b/binrw/tests/derive/write/custom_writer.rs
@@ -38,3 +38,29 @@ fn write_with_fn_once_closure_args() {
     Test { a: 0 }.write(&mut x).unwrap();
     assert_eq!(x.into_inner(), b"\x01");
 }
+
+#[binrw::writer(writer)]
+fn write_as_ref_str<S: AsRef<str>>(value: S) -> binrw::BinResult<()> {
+    let bytes = value.as_ref().as_bytes();
+    writer.write_all(bytes)?;
+    Ok(())
+}
+
+#[test]
+fn write_with_as_ref_str() {
+    use binrw::prelude::*;
+
+    #[derive(BinWrite)]
+    struct MyType {
+        #[bw(write_with = write_as_ref_str)]
+        value: String,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    MyType {
+        value: "Hello, World!".to_string(),
+    }
+    .write_le(&mut x)
+    .unwrap();
+    assert_eq!(x.into_inner(), b"Hello, World!");
+}

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -164,3 +164,26 @@ fn map_lifetime_args() {
 
     assert_eq!(x.into_inner(), b"\x02");
 }
+
+#[test]
+fn try_map_lifetime_args() {
+    #[derive(BinWrite)]
+    #[bw(import(borrowed: &u8))]
+    struct Wrapper(#[bw(map = |&x| x + *borrowed)] u8);
+
+    fn try_map_wrapper(x: &u8) -> binrw::BinResult<Wrapper> {
+        Ok(Wrapper(*x))
+    }
+
+    #[derive(BinWrite, Debug, PartialEq)]
+    #[bw(little, import(borrowed: &u8))]
+    struct Test {
+        #[bw(try_map = try_map_wrapper, args(borrowed))]
+        a: u8,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    Test { a: 1 }.write_args(&mut x, (&1_u8,)).unwrap();
+
+    assert_eq!(x.into_inner(), b"\x02");
+}

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -130,3 +130,18 @@ fn try_map() {
     let mut x = Cursor::new(Vec::new());
     MyType { value: 128 }.write_le(&mut x).unwrap_err();
 }
+
+#[test]
+fn map_write_with() {
+    use binrw::prelude::*;
+
+    #[derive(BinWrite)]
+    struct MyType {
+        #[bw(map = |&x| x as u16, write_with = <u16 as BinWrite>::write_options)]
+        value: u8,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    MyType { value: 127 }.write_le(&mut x).unwrap();
+    assert_eq!(x.into_inner(), b"\x7f\0");
+}

--- a/binrw/tests/derive/write/map.rs
+++ b/binrw/tests/derive/write/map.rs
@@ -145,3 +145,22 @@ fn map_write_with() {
     MyType { value: 127 }.write_le(&mut x).unwrap();
     assert_eq!(x.into_inner(), b"\x7f\0");
 }
+
+#[test]
+fn map_lifetime_args() {
+    #[derive(BinWrite)]
+    #[bw(import(borrowed: &u8))]
+    struct Wrapper(#[bw(map = |&x| x + *borrowed)] u8);
+
+    #[derive(BinWrite, Debug, PartialEq)]
+    #[bw(little, import(borrowed: &u8))]
+    struct Test {
+        #[bw(map = |&x| Wrapper(x), args(borrowed))]
+        a: u8,
+    }
+
+    let mut x = Cursor::new(Vec::new());
+    Test { a: 1 }.write_args(&mut x, (&1_u8,)).unwrap();
+
+    assert_eq!(x.into_inner(), b"\x02");
+}

--- a/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
@@ -290,15 +290,10 @@ impl<'a> StructFieldGenerator<'a> {
                     }
                 }
             },
-            FieldMode::Function(_) => {
-                let ty = &self.field.ty;
-                quote! {
-                    let #args = #WRITE_ARGS_TYPE_HINT::<#ty, _, _, _>(
-                        &#WRITE_FUNCTION, #args_val
-                    );
-                    #out
-                }
-            }
+            FieldMode::Function(_) => quote! {
+                let #args = #WRITE_ARGS_TYPE_HINT(&#WRITE_FUNCTION, #args_val);
+                #out
+            },
             FieldMode::Default => unreachable!("Ignored fields are not written"),
         };
 


### PR DESCRIPTION
This PR fixes several issues I have encountered concerning the `type_hint` functions. Each commit contains a test that did not compile before the commit but does after, along with the change to the respective function. @jam1garner made a Rust Playground example of the error one would see using `map_args_type_hint` before this PR and asked that I include a link to it here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=00295db8351ec33ccd1f30540078af0e.

Most of the issues were weird lifetime bounds as demonstrated by the Rust Playground link. One side-effect of fixing these lifetimes is that custom writers taking `impl AsRef<T>` as input are easier to use. Before these changes, one would need to write `&(impl AsRef<T> + ?Sized)` to make the `type_hint` functions happy. Some of the tests are a little more contrived than others, but they are all based around something I tried to write at one point or another.

There was also the issue that using `map` with `write_with` would not work if the result of the `map` was a different type than the field type, because the invocation of the `type_hint` function restricted the input to the custom writer to be the same type as the field type. I removed the restriction as part of this change set because it seemed related enough to the other changes.

All of the tests passed locally for me, and I even built some of my larger binrw-using projects with this branch and they worked fine. If you have a more comprehensive list of complicated projects using binrw, I would be happy to test with them to minimize any damage done by these changes. In addition to the latest stable and nightly, I made sure I built with Rust version 1.70, which is the Rust version listed in the Cargo.toml.

As always, I am happy to discuss and revise the changes.

P.s. I started using [Jujutsu](https://github.com/jj-vcs/jj), so sorry if there's anything funny with the commits. Let me know and I'll fix it.