### PR TITLE
Macro Hygiene Fixes

### DIFF
--- a/binrw/tests/error.rs
+++ b/binrw/tests/error.rs
@@ -370,3 +370,23 @@ fn show_backtrace_2() {
         }
     );
 }
+
+#[test]
+fn try_map_with_shadowing_box() {
+    use binrw::{io::Cursor, BinRead};
+
+    // Non-standard struct named Box intentionally shadows std::boxed::Box from the prelude
+    #[allow(dead_code)]
+    struct Box;
+
+    #[allow(dead_code)]
+    #[derive(BinRead, Debug)]
+    struct Test {
+        #[br(try_map = |_: u8| Err("Error"))]
+        value: u8,
+    }
+
+    assert!(!Test::read_le(&mut Cursor::new(b"\0"))
+        .expect_err("accepted bad data")
+        .is_eof());
+}

--- a/binrw/tests/error.rs
+++ b/binrw/tests/error.rs
@@ -390,3 +390,24 @@ fn try_map_with_shadowing_box() {
         .expect_err("accepted bad data")
         .is_eof());
 }
+
+#[test]
+fn err_context_with_shadowing_box() {
+    use binrw::{io::Cursor, BinRead};
+
+    // Non-standard struct named Box intentionally shadows std::boxed::Box from the prelude
+    #[allow(dead_code)]
+    struct Box;
+
+    #[allow(dead_code)]
+    #[derive(BinRead, Debug, PartialEq)]
+    struct Test {
+        #[br(err_context(42))]
+        value: u8,
+    }
+
+    assert_eq!(
+        Test::read_le(&mut Cursor::new(b"\0")).unwrap(),
+        Test { value: 0 }
+    );
+}

--- a/binrw/tests/named_args.rs
+++ b/binrw/tests/named_args.rs
@@ -3,6 +3,10 @@ use binrw::NamedArgs;
 #[derive(Eq, PartialEq, Debug)]
 struct NotClone;
 
+// Non-standard struct named Option intentionally shadows std::option::Option from the prelude
+#[allow(dead_code)]
+struct Option;
+
 #[derive(NamedArgs)]
 struct Test<'a, T: Clone, const N: usize> {
     blah: u32,

--- a/binrw_derive/src/binrw/codegen/mod.rs
+++ b/binrw_derive/src/binrw/codegen/mod.rs
@@ -277,9 +277,10 @@ fn get_endian(endian: &CondEndian) -> TokenStream {
 fn get_map_err(pos: IdentStr, span: Span) -> TokenStream {
     quote_spanned_any! { span=>
         .map_err(|e| {
+            extern crate alloc;
             #BIN_ERROR::Custom {
                 pos: #pos,
-                err: Box::new(e) as _,
+                err: alloc::boxed::Box::new(e) as _,
             }
         })
     }

--- a/binrw_derive/src/binrw/codegen/read_options.rs
+++ b/binrw_derive/src/binrw/codegen/read_options.rs
@@ -42,7 +42,7 @@ pub(crate) fn generate(input: &Input, derive_input: &syn::DeriveInput) -> TokenS
                 map::generate_try_map(
                     input,
                     name,
-                    &quote! { <#ty as core::convert::TryInto<_>>::try_into },
+                    &quote! { <#ty as ::core::convert::TryInto<_>>::try_into },
                 ),
                 true,
             ),

--- a/binrw_derive/src/binrw/codegen/read_options/struct.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/struct.rs
@@ -437,7 +437,7 @@ impl<'field> FieldGenerator<'field> {
 
     fn read_value(mut self) -> Self {
         self.out = match &self.field.field_mode {
-            FieldMode::Default => quote! { <_>::default() },
+            FieldMode::Default => quote! { ::core::default::Default::default() },
             FieldMode::Calc(calc) => quote! { #calc },
             FieldMode::TryCalc(calc) => get_try_calc(POS, &self.field.ty, calc),
             read_mode @ (FieldMode::Normal | FieldMode::Function(_)) => {
@@ -499,10 +499,10 @@ impl<'field> FieldGenerator<'field> {
         if let Some(cond) = &self.field.if_cond {
             let condition = &cond.condition;
             let consequent = self.out;
-            let alternate = cond
-                .alternate
-                .as_ref()
-                .map_or_else(|| Cow::Owned(quote! { <_>::default() }), Cow::Borrowed);
+            let alternate = cond.alternate.as_ref().map_or_else(
+                || Cow::Owned(quote! { ::core::default::Default::default() }),
+                Cow::Borrowed,
+            );
             self.out = quote! {
                 if #condition {
                     #consequent

--- a/binrw_derive/src/binrw/codegen/read_options/struct.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/struct.rs
@@ -321,7 +321,7 @@ impl<'field> FieldGenerator<'field> {
             Map::Try(try_map) | Map::Repr(try_map) => {
                 let try_map = if matches!(self.field.map, Map::Repr(_)) {
                     quote! {
-                        <#try_map as core::convert::TryInto<_>>::try_into
+                        <#try_map as ::core::convert::TryInto<_>>::try_into
                     }
                 } else {
                     try_map.clone()

--- a/binrw_derive/src/binrw/codegen/read_options/struct.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/struct.rs
@@ -547,7 +547,10 @@ fn get_err_context(
 ) -> TokenStream {
     let backtrace = if let Some(ErrContext::Context(expr)) = &field.err_context {
         quote_spanned! {field.ident.span()=>
-            #BACKTRACE_FRAME::Custom(Box::new(#expr) as _)
+            {
+                extern crate alloc;
+                #BACKTRACE_FRAME::Custom(alloc::boxed::Box::new(#expr) as _)
+            }
         }
     } else {
         #[cfg(feature = "verbose-backtrace")]

--- a/binrw_derive/src/binrw/codegen/write_options.rs
+++ b/binrw_derive/src/binrw/codegen/write_options.rs
@@ -46,7 +46,7 @@ fn generate_map(input: &Input, name: Option<&Ident>, map: &TokenStream) -> Token
         quote! { #map_err? }
     });
     let map = if matches!(input.map(), Map::Repr(_)) {
-        quote! { <#map as core::convert::TryFrom<_>>::try_from }
+        quote! { <#map as ::core::convert::TryFrom<_>>::try_from }
     } else {
         map.clone()
     };

--- a/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
+++ b/binrw_derive/src/binrw/codegen/write_options/struct_field.rs
@@ -333,7 +333,7 @@ fn args_ident(ident: &Ident) -> Ident {
 fn field_mapping(map: &Map) -> Option<TokenStream> {
     match map {
         Map::Try(map_fn) | Map::Map(map_fn) => Some(quote! { (#map_fn) }),
-        Map::Repr(ty) => Some(quote! { (<#ty as core::convert::TryFrom<_>>::try_from) }),
+        Map::Repr(ty) => Some(quote! { (<#ty as ::core::convert::TryFrom<_>>::try_from) }),
         Map::None => None,
     }
 }

--- a/binrw_derive/src/named_args/codegen.rs
+++ b/binrw_derive/src/named_args/codegen.rs
@@ -365,7 +365,9 @@ impl BuilderField {
         let name = &self.name;
         let ty = &self.ty;
         let ty = match self.kind {
-            BuilderFieldKind::Required | BuilderFieldKind::TryOptional => quote!(Option<#ty>),
+            BuilderFieldKind::Required | BuilderFieldKind::TryOptional => {
+                quote!(::core::option::Option<#ty>)
+            }
             BuilderFieldKind::Optional { .. } => quote!(#ty),
         };
         quote!(

--- a/binrw_derive/src/named_args/codegen.rs
+++ b/binrw_derive/src/named_args/codegen.rs
@@ -66,9 +66,9 @@ impl Builder<'_> {
             });
 
             let derives = if self.are_all_fields_optional() {
-                quote!(#[derive(Clone, Default)])
+                quote!(#[derive(::core::clone::Clone, ::core::default::Default)])
             } else {
-                quote!(#[derive(Clone)])
+                quote!(#[derive(::core::clone::Clone)])
             };
             Some(quote!(
                 #derives

--- a/binrw_derive/src/named_args/codegen.rs
+++ b/binrw_derive/src/named_args/codegen.rs
@@ -333,7 +333,7 @@ impl Builder<'_> {
                             #( #satisfied_generics ),*
                         >
                     where
-                        #current_field_ty: Default,
+                        #current_field_ty: ::core::default::Default,
                     {
                         /// Builds the object.
                         #vis fn finalize(self) -> #name < #user_generic_args > {


### PR DESCRIPTION
Some fixes to try and more fully qualify crate, type, trait, and derive macros names in generated code. I originally got hit by one of the unqualified `Box`s and got a hard-to-diagnose error, but saw a few more places that could be cleaned up, so I went a little overboard. I probably missed some. If you have a better way to find unqualified identifiers in quote blocks, let me know. I tried to keep with the conventions I saw being used around the codebase, but I may have failed with that.

I did see that `ident_str!` is used for most of the identifiers coming from the `binrw` crate, but when they are turned into tokens, no leading `::` appears to be prepended. I didn't do anything about that, but figured I'd mention it since it's related to macro hygiene.
