### PR TITLE
Add `align_size_to` field-level attribute

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -92,6 +92,7 @@ Glossary of directives in binrw attributes (`#[br]`, `#[bw]`, `#[brw]`).
 |-----|-----------|----------|------------
 | rw  | [`align_after`](#padding-and-alignment) | field | Aligns the <span class="br">reader</span><span class="bw">writer</span> to the Nth byte after a field.
 | rw  | [`align_before`](#padding-and-alignment) | field | Aligns the <span class="br">reader</span><span class="bw">writer</span> to the Nth byte before a field.
+| rw  | [`align_size_to`](#padding-and-alignment) | field | Ensures the <span class="br">reader</span><span class="bw">writer</span> is always advanced by a multiple of N bytes.
 | rw  | [`args`](#arguments) | field | Passes arguments to another binrw object.
 | rw  | [`args_raw`](#arguments) | field | Like `args`, but specifies a single variable containing the arguments.
 | rw  | [`assert`](#assert) | struct, field, non-unit enum, data variant | Asserts that a condition is true. Can be used multiple times.
@@ -2120,6 +2121,25 @@ at least 256 bytes for that string, [`NullString`](crate::NullString) will
 read the string and `pad_size_to(256)` will ensure the reader skips whatever
 padding, if any, remains. If the string is longer than 256 bytes, no padding
 will be skipped.
+
+---
+
+The `align_size_to` directive will ensure that the
+<span class="br">reader</span><span class="bw">writer</span> has advanced a multiple of the number of bytes given after the field has been
+<span class="br">read</span><span class="bw">written</span>:
+
+<div class="br">
+
+```text
+#[br(align_size_to = $size:expr)] or #[br(align_size_to($size:expr))]
+```
+</div>
+<div class="bw">
+
+```text
+#[bw(align_size_to = $size:expr)] or #[bw(align_size_to($size:expr))]
+```
+</div>
 
 Any <span class="brw">(earlier only, when reading)</span><span class="br">earlier</span>
 field or [import](#arguments) can be

--- a/binrw/tests/dbg.rs
+++ b/binrw/tests/dbg.rs
@@ -20,12 +20,14 @@ fn dbg() {
         last: u8,
         #[br(dbg)]
         terminator: u8,
+        #[br(dbg, align_size_to = 2)]
+        after: u8,
     }
 
     // 🥴
     if let Some("1") = option_env!("BINRW_IN_CHILD_PROC") {
         Test::read(&mut Cursor::new(
-            b"\0\0\xff\xff\0\0\0\x04\xff\xff\0\x0e\xff\xed\xff\xff\x42\0\0\0\x69",
+            b"\0\0\xff\xff\0\0\0\x04\xff\xff\0\x0e\xff\xed\xff\xff\x42\0\0\0\x69\x25\0",
         ))
         .unwrap();
     } else {
@@ -55,12 +57,15 @@ fn dbg() {
                     "[{file}:{offset_2} | offset 0x10] last = 0x42\n",
                     "[{file}:{offset_2} | pad_size_to 0x4]\n",
                     "[{file}:{offset_3} | offset 0x14] terminator = 0x69\n",
+                    "[{file}:{offset_4} | offset 0x15] after = 0x25\n",
+                    "[{file}:{offset_4} | align_size_to 0x2]\n",
                 ),
                 file = core::file!(),
                 offset_0 = if cfg!(nightly) { 16 } else { 11 },
                 offset_1 = if cfg!(nightly) { 18 } else { 11 },
                 offset_2 = if cfg!(nightly) { 20 } else { 11 },
                 offset_3 = if cfg!(nightly) { 22 } else { 11 },
+                offset_4 = if cfg!(nightly) { 24 } else { 11 },
             )
         );
     }

--- a/binrw/tests/derive/struct.rs
+++ b/binrw/tests/derive/struct.rs
@@ -680,6 +680,19 @@ fn pad_size_to() {
 }
 
 #[test]
+fn align_size_to() {
+    #[derive(BinRead, Debug, PartialEq)]
+    struct Test {
+        #[br(align_size_to = 3)]
+        a: u32,
+        b: u8,
+    }
+
+    let result = Test::read_le(&mut Cursor::new(b"\x01\0\0\0\0\0\x02")).unwrap();
+    assert_eq!(result, Test { a: 1, b: 2 });
+}
+
+#[test]
 fn parse_with_default_args() {
     #[derive(Clone)]
     struct Args(u8);

--- a/binrw/tests/derive/write/padding.rs
+++ b/binrw/tests/derive/write/padding.rs
@@ -25,12 +25,16 @@ fn padding_round_trip() {
 
         #[brw(pad_size_to = 0x6_u32)]
         z: u32,
+
+        #[brw(align_size_to = 0x3_u32)]
+        w: u32,
     }
 
     let data = &[
         /* pad_before: */ 0, 0, /* x */ 1, /* align: */ 0, 0, 0, 0, 0,
         /* align_before: (none)*/ /* y */ 2, /* pad_after: */ 0, 0, 0, /* z */ 0,
-        0xab, 0xcd, 0xef, /* pad_size_to */ 0, 0,
+        0xab, 0xcd, 0xef, /* pad_size_to */ 0, 0, /* w */ 0x25,
+        /* align_size_to */ 0, 0, 0, 0, 0,
     ];
     let test: Test = Cursor::new(data).read_be().unwrap();
 
@@ -53,12 +57,16 @@ fn padding_one_way() {
 
         #[brw(pad_size_to = 0x6_u32)]
         z: u32,
+
+        #[brw(align_size_to = 0x3_u32)]
+        w: u32,
     }
 
     let data = &[
         /* pad_before: */ 0, 0, /* x */ 1, /* align: */ 0, 0, 0, 0, 0,
         /* align_before: (none)*/ /* y */ 2, /* pad_after: */ 0, 0, 0, /* z */ 0xef,
-        0xcd, 0xab, 0, /* pad_size_to */ 0, 0,
+        0xcd, 0xab, 0, /* pad_size_to */ 0, 0, /* w */ 0x25, /* align_size_to */ 0,
+        0, 0, 0, 0,
     ];
 
     let mut x = Cursor::new(Vec::new());
@@ -67,6 +75,7 @@ fn padding_one_way() {
         x: 1,
         y: 2,
         z: 0xabcdef,
+        w: 0x25,
     }
     .write_options(&mut x, Endian::Little, ())
     .unwrap();

--- a/binrw/tests/ui/invalid_keyword_struct_field.stderr
+++ b/binrw/tests/ui/invalid_keyword_struct_field.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `align_size_to`, `dbg`
  --> tests/ui/invalid_keyword_struct_field.rs:5:10
   |
 5 |     #[br(invalid_struct_field_keyword)]

--- a/binrw/tests/ui/non_blocking_errors.stderr
+++ b/binrw/tests/ui/non_blocking_errors.stderr
@@ -4,13 +4,13 @@ error: expected one of: `stream`, `big`, `little`, `is_big`, `is_little`, `map`,
 6 | #[br(invalid_keyword_struct)]
   |      ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `align_size_to`, `dbg`
  --> tests/ui/non_blocking_errors.rs:8:10
   |
 8 |     #[br(invalid_keyword_struct_field_a)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `dbg`
+error: expected one of: `big`, `little`, `is_big`, `is_little`, `map`, `try_map`, `repr`, `map_stream`, `magic`, `args`, `args_raw`, `calc`, `try_calc`, `default`, `ignore`, `parse_with`, `count`, `offset`, `if`, `restore_position`, `try`, `temp`, `assert`, `err_context`, `pad_before`, `pad_after`, `align_before`, `align_after`, `seek_before`, `pad_size_to`, `align_size_to`, `dbg`
   --> tests/ui/non_blocking_errors.rs:10:10
    |
 10 |     #[br(invalid_keyword_struct_field_b)]

--- a/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
+++ b/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
@@ -192,7 +192,8 @@ fn visit_expr_attributes(field: &StructField, visitor: &mut Visitor) {
         align_before,
         align_after,
         seek_before,
-        pad_size_to
+        pad_size_to,
+        align_size_to
     );
 
     if let Some(condition) = field.if_cond.clone() {

--- a/binrw_derive/src/binrw/parser/attrs.rs
+++ b/binrw_derive/src/binrw/parser/attrs.rs
@@ -7,6 +7,7 @@ use syn::{Expr, FieldValue, Token};
 
 pub(super) type AlignAfter = MetaExpr<kw::align_after>;
 pub(super) type AlignBefore = MetaExpr<kw::align_before>;
+pub(super) type AlignSizeTo = MetaExpr<kw::align_size_to>;
 pub(super) type Args = MetaEnclosedList<kw::args, Expr, FieldValue>;
 pub(super) type ArgsRaw = MetaExpr<kw::args_raw>;
 pub(super) type AssertLike<Keyword> = MetaList<Keyword, Expr>;

--- a/binrw_derive/src/binrw/parser/field_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/field_level_attrs.rs
@@ -56,6 +56,8 @@ attr_struct! {
         pub(crate) seek_before: Option<TokenStream>,
         #[from(RW:PadSizeTo)]
         pub(crate) pad_size_to: Option<TokenStream>,
+        #[from(RW:AlignSizeTo)]
+        pub(crate) align_size_to: Option<TokenStream>,
         #[from(RO:Debug)] // TODO is this really RO?
         pub(crate) debug: Option<()>,
     }
@@ -128,6 +130,7 @@ impl StructField {
                 align_after,
                 seek_before,
                 pad_size_to,
+                align_size_to,
                 magic
             )
     }
@@ -239,6 +242,7 @@ impl FromField for StructField {
             align_after: <_>::default(),
             seek_before: <_>::default(),
             pad_size_to: <_>::default(),
+            align_size_to: <_>::default(),
             #[cfg(feature = "verbose-backtrace")]
             keyword_spans: <_>::default(),
             err_context: <_>::default(),

--- a/binrw_derive/src/binrw/parser/keywords.rs
+++ b/binrw_derive/src/binrw/parser/keywords.rs
@@ -9,6 +9,7 @@ macro_rules! define_keywords {
 define_keywords! {
     align_after,
     align_before,
+    align_size_to,
     args,
     args_raw,
     assert,


### PR DESCRIPTION
This PR rounds off the `pad_`/`align_` attribute symmetry by adding the counterpart to `pad_size_to`. I would especially appreciate any feedback on the documentation. In the future, I intend to pick up https://github.com/jam1garner/binrw/pull/250 and add both `_size_to` attributes at the struct/enum-level, if nobody beats me to it.