### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ struct Dog {
 let mut reader = Cursor::new(b"DOG\x02\x00\x01\x00\x12\0\0Rudy\0");
 let dog: Dog = reader.read_ne().unwrap();
 assert_eq!(dog.bone_piles, &[0x1, 0x12]);
-assert_eq!(dog.name.into_string(), "Rudy")
+assert_eq!(dog.name.to_string(), "Rudy")
 ```
 
 For more information, including a more detailed overview of binrw,


### PR DESCRIPTION
smol PR, just wanted to tidy this up.

`NullString` doesn't implement `into_string`, but it does implement the `Display` trait.