### PR TITLE
Fix panic with modular-bitfield on nightly

### DIFF
--- a/binrw/tests/bitfield.rs
+++ b/binrw/tests/bitfield.rs
@@ -1,0 +1,12 @@
+#[test]
+fn modular_bitfield() {
+    use binrw_derive::binread;
+    use modular_bitfield::prelude::{bitfield, B8};
+
+    #[allow(dead_code)]
+    #[bitfield]
+    #[binread]
+    struct Foo {
+        bits: B8,
+    }
+}

--- a/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
+++ b/binrw_derive/src/binrw/backtrace/syntax_highlighting.rs
@@ -87,8 +87,10 @@ impl SyntaxInfo {
 
         let line = self.lines.entry(start.line()).or_default();
 
-        assert_eq!(start.line(), end.line());
-        line.highlights.push((start.column()..end.column(), color));
+        // syntax highlighting for multi-line spans isn't supported yet (sorry)
+        if start.line() == end.line() {
+            line.highlights.push((start.column()..end.column(), color));
+        }
     }
 }
 


### PR DESCRIPTION
Only seen on nightly because `backtrace/mod.rs` only provides non-zero lines and columns with `#[cfg(all(feature = "verbose-backtrace", nightly, proc_macro))]`.

Simply skip the highlighting if the span spans multiple lines, similarly to how multi-line spans are already not supported by `Visitor::visit_lit` below.

Fixes #354.