### PR TITLE
Hygienic identifiers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.70" # rust-version, msrv
+          - "1.76" # rust-version, msrv
         features:
           - name: all features
             value: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ homepage = "https://binrw.rs"
 license = "MIT"
 publish = false # Use `release.sh`
 repository = "https://github.com/jam1garner/binrw"
-rust-version = "1.70"
+rust-version = "1.76"
 version = "0.16.0-pre"

--- a/binrw/src/io/no_std/error.rs
+++ b/binrw/src/io/no_std/error.rs
@@ -84,6 +84,12 @@ impl Error {
         }
     }
 
+    /// Creates a new I/O error with [`ErrorKind::Other`].
+    #[must_use]
+    pub fn other<A>(error: A) -> Self {
+        Self::new(ErrorKind::Other, error)
+    }
+
     /// Returns the corresponding [`ErrorKind`] for this error.
     #[must_use]
     pub fn kind(&self) -> ErrorKind {

--- a/binrw/src/io/no_std/error.rs
+++ b/binrw/src/io/no_std/error.rs
@@ -64,6 +64,8 @@ pub enum ErrorKind {
     TimedOut,
     /// An error returned when an operation could not be completed because a
     /// call to [`write`] returned [`Ok(0)`].
+    ///
+    /// [`Ok(0)`]: core::result::Result::Ok
     WriteZero,
     /// This operation was interrupted.
     Interrupted,

--- a/binrw/src/io/seek.rs
+++ b/binrw/src/io/seek.rs
@@ -1,6 +1,6 @@
 //! Wrapper type that provides a fake [`Seek`](crate::io::Seek) implementation.
 
-use super::{Error, ErrorKind, SeekFrom};
+use super::{Error, SeekFrom};
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
@@ -45,7 +45,7 @@ impl<T> super::Seek for NoSeek<T> {
             SeekFrom::Start(n) if self.pos == n => Ok(n),
             SeekFrom::Current(0) => Ok(self.pos),
             // https://github.com/rust-lang/rust/issues/86442
-            _ => Err(Error::new(ErrorKind::Other, "seek on unseekable file")),
+            _ => Err(Error::other("seek on unseekable file")),
         }
     }
 

--- a/binrw/tests/derive/lib.rs
+++ b/binrw/tests/derive/lib.rs
@@ -15,6 +15,7 @@ mod t {
 mod binwrite_temp;
 mod r#enum;
 mod fn_helper;
+mod macro_hygiene;
 mod map_args;
 mod r#struct;
 mod struct_generic;

--- a/binrw/tests/derive/macro_hygiene.rs
+++ b/binrw/tests/derive/macro_hygiene.rs
@@ -1,0 +1,217 @@
+extern crate binrw;
+use super::t;
+
+macro_rules! derive_binread {
+    ($item:item) => {
+        #[derive(::core::fmt::Debug, ::core::cmp::PartialEq, ::binrw::BinRead)]
+        $item
+    };
+}
+
+macro_rules! derive_binwrite {
+    ($item:item) => {
+        #[derive(::core::fmt::Debug, ::core::cmp::PartialEq, ::binrw::BinWrite)]
+        $item
+    };
+}
+
+macro_rules! derive_binrw {
+    ($item:item) => {
+        #[derive(
+            ::core::fmt::Debug, ::core::cmp::PartialEq, ::binrw::BinRead, ::binrw::BinWrite,
+        )]
+        $item
+    };
+}
+
+derive_binrw! {
+    #[br(import(v: bool))]
+    enum PreAssertEnum {
+        #[br(pre_assert(v))]
+        A(u32),
+        #[br(pre_assert(!v))]
+        B(u32),
+    }
+}
+
+derive_binrw! {
+    #[br(assert(x == 1))]
+    #[bw(assert(*x == 1))]
+    struct Asserted {
+        x: u8,
+    }
+}
+
+derive_binread! {
+    #[br(import(len: usize))]
+    struct Counted {
+        #[br(count = len)]
+        values: t::Vec<u8>,
+    }
+}
+
+#[binrw::parser(reader, endian)]
+fn parse_one_byte() -> binrw::BinResult<u8> {
+    <u8 as ::binrw::BinRead>::read_options(reader, endian, ())
+}
+
+derive_binread! {
+    struct ParseWithField {
+        #[br(parse_with = parse_one_byte)]
+        value: u8,
+    }
+}
+
+derive_binrw! {
+    #[br(map_stream = |reader| reader)]
+    #[bw(map_stream = |writer| writer)]
+    struct TopLevelMapStream {
+        value: u8,
+    }
+}
+
+derive_binrw! {
+    struct FieldMapStream {
+        #[br(map_stream = |reader| reader)]
+        #[bw(map_stream = |writer| writer)]
+        value: u8,
+    }
+}
+
+derive_binread! {
+    struct MapRead {
+        #[br(map = |x: u8| x + 1)]
+        value: u8,
+    }
+}
+
+derive_binread! {
+    struct TryMapRead {
+        #[br(try_map = |x: u16| <u8 as ::core::convert::TryFrom<_>>::try_from(x))]
+        value: u8,
+    }
+}
+
+derive_binwrite! {
+    struct MapWrite {
+        #[bw(map = |&x| x as u16)]
+        value: u8,
+    }
+}
+
+derive_binwrite! {
+    struct TryMapWrite {
+        #[bw(try_map = |&x| <u8 as ::core::convert::TryFrom<_>>::try_from(x))]
+        value: u16,
+    }
+}
+
+#[test]
+fn derive_macro_pre_assert_hygiene() {
+    let a = <PreAssertEnum as binrw::BinRead>::read_be_args(
+        &mut binrw::io::Cursor::new(b"\0\0\0\x01"),
+        (true,),
+    )
+    .unwrap();
+    t::assert_eq!(a, PreAssertEnum::A(1));
+
+    let b = <PreAssertEnum as binrw::BinRead>::read_be_args(
+        &mut binrw::io::Cursor::new(b"\0\0\0\x01"),
+        (false,),
+    )
+    .unwrap();
+    t::assert_eq!(b, PreAssertEnum::B(1));
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <PreAssertEnum as binrw::BinWrite>::write_be(&PreAssertEnum::A(2), &mut out).unwrap();
+    t::assert_eq!(out.into_inner(), b"\0\0\0\x02");
+}
+
+#[test]
+fn derive_macro_assert_hygiene() {
+    let ok = <Asserted as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x01")).unwrap();
+    t::assert_eq!(ok, Asserted { x: 1 });
+
+    let err =
+        <Asserted as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x00")).unwrap_err();
+    t::assert!(t::matches!(err, binrw::Error::AssertFail { .. }));
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <Asserted as binrw::BinWrite>::write_le(&Asserted { x: 1 }, &mut out).unwrap();
+    t::assert_eq!(out.into_inner(), b"\x01");
+
+    let err = <Asserted as binrw::BinWrite>::write_le(
+        &Asserted { x: 0 },
+        &mut binrw::io::Cursor::new(t::vec![]),
+    )
+    .unwrap_err();
+    t::assert!(t::matches!(err, binrw::Error::AssertFail { .. }));
+}
+
+#[test]
+fn derive_macro_count_hygiene() {
+    let counted =
+        <Counted as binrw::BinRead>::read_le_args(&mut binrw::io::Cursor::new(b"\x01\x02"), (2,))
+            .unwrap();
+    t::assert_eq!(counted.values, t::vec![1, 2]);
+}
+
+#[test]
+fn derive_macro_parse_with_hygiene() {
+    let parsed =
+        <ParseWithField as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x2a")).unwrap();
+    t::assert_eq!(parsed, ParseWithField { value: 0x2a });
+}
+
+#[test]
+fn derive_macro_map_stream_hygiene() {
+    let read_top =
+        <TopLevelMapStream as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x11"))
+            .unwrap();
+    t::assert_eq!(read_top, TopLevelMapStream { value: 0x11 });
+
+    let read_field =
+        <FieldMapStream as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x22")).unwrap();
+    t::assert_eq!(read_field, FieldMapStream { value: 0x22 });
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <TopLevelMapStream as binrw::BinWrite>::write_le(&TopLevelMapStream { value: 0x33 }, &mut out)
+        .unwrap();
+    t::assert_eq!(out.into_inner(), b"\x33");
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <FieldMapStream as binrw::BinWrite>::write_le(&FieldMapStream { value: 0x44 }, &mut out)
+        .unwrap();
+    t::assert_eq!(out.into_inner(), b"\x44");
+}
+
+#[test]
+fn derive_macro_map_hygiene() {
+    let mapped =
+        <MapRead as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x01")).unwrap();
+    t::assert_eq!(mapped, MapRead { value: 2 });
+
+    let try_mapped_ok =
+        <TryMapRead as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\x7f\0")).unwrap();
+    t::assert_eq!(try_mapped_ok, TryMapRead { value: 127 });
+
+    let try_mapped_err =
+        <TryMapRead as binrw::BinRead>::read_le(&mut binrw::io::Cursor::new(b"\0\x01"))
+            .unwrap_err();
+    t::assert!(t::matches!(try_mapped_err, binrw::Error::Custom { .. }));
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <MapWrite as binrw::BinWrite>::write_le(&MapWrite { value: 5 }, &mut out).unwrap();
+    t::assert_eq!(out.into_inner(), b"\x05\0");
+
+    let mut out = binrw::io::Cursor::new(t::vec![]);
+    <TryMapWrite as binrw::BinWrite>::write_le(&TryMapWrite { value: 127 }, &mut out).unwrap();
+    t::assert_eq!(out.into_inner(), b"\x7f");
+
+    let err = <TryMapWrite as binrw::BinWrite>::write_le(
+        &TryMapWrite { value: 256 },
+        &mut binrw::io::Cursor::new(t::vec![]),
+    )
+    .unwrap_err();
+    t::assert!(t::matches!(err, binrw::Error::Custom { .. }));
+}

--- a/binrw/tests/error.rs
+++ b/binrw/tests/error.rs
@@ -82,17 +82,8 @@ fn display() {
     assert!(err.contains("0x42"));
     assert!(err.contains("57005"));
 
-    let err = format!(
-        "{}",
-        Error::Io(binrw::io::Error::new(binrw::io::ErrorKind::Other, "Oops"))
-    );
-    assert_eq!(
-        err,
-        format!(
-            "{}",
-            binrw::io::Error::new(binrw::io::ErrorKind::Other, "Oops")
-        )
-    );
+    let err = format!("{}", Error::Io(binrw::io::Error::other("Oops")));
+    assert_eq!(err, format!("{}", binrw::io::Error::other("Oops")));
     #[cfg(feature = "std")]
     assert!(err.contains("Oops"));
     #[cfg(not(feature = "std"))]

--- a/binrw/tests/ui/args_missing.stderr
+++ b/binrw/tests/ui/args_missing.stderr
@@ -5,8 +5,8 @@ error[E0277]: the trait bound `NoDefault: Default` is not satisfied
    |        ^^^ the trait `Default` is not implemented for `NoDefault`
    |
    = note: required for `(NoDefault,)` to implement `Default`
-   = note: required for `(NoDefault,)` to implement `MissingArgsDirective`
-note: required by a bound in `Required::args`
+   = note: required for `(NoDefault,)` to implement `binrw::__private::MissingArgsDirective`
+note: required by a bound in `binrw::__private::Required::args`
   --> src/private.rs
    |
    | pub trait Required: MissingArgsDirective {
@@ -15,6 +15,6 @@ note: required by a bound in `Required::args`
    |        ---- required by a bound in this associated function
 help: consider annotating `NoDefault` with `#[derive(Default)]`
    |
-4  + #[derive(Default)]
-5  | struct NoDefault;
+ 4 + #[derive(Default)]
+ 5 | struct NoDefault;
    |

--- a/binrw/tests/ui/args_vec_mistakes.stderr
+++ b/binrw/tests/ui/args_vec_mistakes.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `VecArgs<()>: MissingArgsDirective` is not satisfied
+error[E0277]: the trait bound `VecArgs<()>: binrw::__private::MissingArgsDirective` is not satisfied
  --> tests/ui/args_vec_mistakes.rs:7:20
   |
 7 | struct MissingArgs(Vec<u8>);
   |                    ^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`
   |
-  = note: required for `VecArgs<()>` to implement `MissingArgsDirective`
-note: required by a bound in `Required::args`
+  = note: required for `VecArgs<()>` to implement `binrw::__private::MissingArgsDirective`
+note: required by a bound in `binrw::__private::Required::args`
  --> src/private.rs
   |
   | pub trait Required: MissingArgsDirective {
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
    = note: expected struct `VecArgs<()>`
                found tuple `((),)`
 
-error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::VecArgsBuilder<(), Needed, Satisfied>`, but its trait bounds were not satisfied
+error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::VecArgsBuilder<(), binrw::__private::Needed, binrw::__private::Satisfied>`, but its trait bounds were not satisfied
   --> tests/ui/args_vec_mistakes.rs:13:26
    |
 13 | struct MissingCount(#[br(args { inner: () })] Vec<u8>);
@@ -33,10 +33,10 @@ error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::Ve
   ::: src/named_args.rs
    |
    | pub struct Needed;
-   | ----------------- doesn't satisfy `Needed: SatisfiedOrOptional`
+   | ----------------- doesn't satisfy `_: SatisfiedOrOptional`
    |
    = note: the following trait bounds were not satisfied:
-           `Needed: SatisfiedOrOptional`
+           `binrw::__private::Needed: binrw::__private::SatisfiedOrOptional`
    = note: this error originates in the macro `binrw::args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: TryFrom<Option<{integer}>>` is not satisfied
@@ -45,18 +45,35 @@ error[E0277]: the trait bound `usize: TryFrom<Option<{integer}>>` is not satisfi
 22 | struct WrongCountType(#[br(count = Some(1))] Vec<u8>);
    |                                    ^^^^^^^ the trait `From<Option<{integer}>>` is not implemented for `usize`
    |
-   = help: the following other types implement trait `From<T>`:
-             `usize` implements `From<bool>`
-             `usize` implements `From<std::ptr::Alignment>`
-             `usize` implements `From<u16>`
-             `usize` implements `From<u8>`
+help: the following other types implement trait `From<T>`
+  --> $RUST/core/src/convert/num.rs
+   |
+   = note: `usize` implements `From<bool>`
+  ::: $RUST/core/src/convert/num.rs
+   |
+   = note: in this macro invocation
+  ::: $RUST/core/src/convert/num.rs
+   |
+   = note: `usize` implements `From<u16>`
+   |
+   = note: `usize` implements `From<u8>`
+  ::: $RUST/core/src/convert/num.rs
+   |
+   = note: in this macro invocation
+  ::: $RUST/core/src/convert/num.rs
+   |
+   = note: in this macro invocation
+  --> $RUST/core/src/ptr/alignment.rs
+   |
+   = note: `usize` implements `From<std::ptr::Alignment>`
    = note: required for `Option<{integer}>` to implement `Into<usize>`
    = note: required for `usize` to implement `TryFrom<Option<{integer}>>`
+   = note: this error originates in the macro `impl_from_bool` which comes from the expansion of the macro `impl_from` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::VecArgsBuilder<(NoDefault,), Satisfied, Needed>`, but its trait bounds were not satisfied
+error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::VecArgsBuilder<(NoDefault,), binrw::__private::Satisfied, binrw::__private::Needed>`, but its trait bounds were not satisfied
   --> tests/ui/args_vec_mistakes.rs:25:42
    |
-4  | struct NoDefault;
+ 4 | struct NoDefault;
    | ---------------- doesn't satisfy `NoDefault: Default`
 ...
 25 | struct MissingInnerArgs(#[br(count = 1)] Vec<Inner>);
@@ -65,26 +82,26 @@ error[E0599]: the method `finalize` exists for struct `binrw::binread::impls::Ve
   ::: src/named_args.rs
    |
    | pub struct Needed;
-   | ----------------- doesn't satisfy `Needed: SatisfiedOrOptional`
+   | ----------------- doesn't satisfy `_: SatisfiedOrOptional`
    |
    = note: the following trait bounds were not satisfied:
            `NoDefault: Default`
            which is required by `(NoDefault,): Default`
-           `Needed: SatisfiedOrOptional`
+           `binrw::__private::Needed: binrw::__private::SatisfiedOrOptional`
    = note: this error originates in the macro `binrw::args` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoDefault` with `#[derive(Default)]`
    |
-4  + #[derive(Default)]
-5  | struct NoDefault;
+ 4 + #[derive(Default)]
+ 5 | struct NoDefault;
    |
 
-error[E0277]: the trait bound `VecArgs<()>: Required` is not satisfied
+error[E0277]: the trait bound `VecArgs<()>: binrw::__private::Required` is not satisfied
   --> tests/ui/args_vec_mistakes.rs:28:5
    |
 28 |     Vec::<u8>::read(&mut binrw::io::Cursor::new(b"")).unwrap();
    |     ^^^^^^^^^ the trait `Default` is not implemented for `VecArgs<()>`
    |
-   = note: required for `VecArgs<()>` to implement `Required`
+   = note: required for `VecArgs<()>` to implement `binrw::__private::Required`
 note: required by a bound in `binrw::BinRead::read`
   --> src/binread/mod.rs
    |

--- a/binrw/tests/ui/bad_parse_with_fn.stderr
+++ b/binrw/tests/ui/bad_parse_with_fn.stderr
@@ -11,7 +11,7 @@ error[E0277]: expected a `FnOnce(&mut _, binrw::Endian, _)` closure, found `{int
    |                       ^^ expected an `FnOnce(&mut _, binrw::Endian, _)` closure, found `{integer}`
    |
    = help: the trait `for<'a> FnOnce(&'a mut _, binrw::Endian, _)` is not implemented for `{integer}`
-note: required by a bound in `parse_fn_type_hint`
+note: required by a bound in `binrw::__private::parse_fn_type_hint`
   --> src/private.rs
    |
    | pub fn parse_fn_type_hint<Ret, ParseFn, R, Args>(f: ParseFn) -> ParseFn

--- a/binrw/tests/ui/bad_parse_with_map.stderr
+++ b/binrw/tests/ui/bad_parse_with_map.stderr
@@ -9,7 +9,7 @@ error[E0271]: expected `from_utf8_lossy` to return `String`, but it returns `Cow
   |
   = note: expected struct `String`
                found enum `Cow<'_, str>`
-note: required by a bound in `coerce_fn`
+note: required by a bound in `binrw::__private::coerce_fn`
  --> src/private.rs
   |
   | pub fn coerce_fn<R, T, F>(f: F) -> F

--- a/binrw/tests/ui/invalid_assert_condition.stderr
+++ b/binrw/tests/ui/invalid_assert_condition.stderr
@@ -1,13 +1,13 @@
 error[E0308]: mismatched types
-  --> tests/ui/invalid_assert_condition.rs:4:13
-   |
-4  | #[br(assert("wrong type"))]
-   |      ------ ^^^^^^^^^^^^ expected `bool`, found `&str`
-   |      |
-   |      arguments to this function are incorrect
-   |
+ --> tests/ui/invalid_assert_condition.rs:4:13
+  |
+4 | #[br(assert("wrong type"))]
+  |      ------ ^^^^^^^^^^^^ expected `bool`, found `&str`
+  |      |
+  |      arguments to this function are incorrect
+  |
 note: function defined here
-  --> src/private.rs
-   |
-   | pub fn assert<MsgFn, Msg, ErrorFn, Err>(
-   |        ^^^^^^
+ --> src/private.rs
+  |
+  | pub fn assert<MsgFn, Msg, ErrorFn, Err>(
+  |        ^^^^^^

--- a/binrw/tests/ui/invalid_assert_variable.stderr
+++ b/binrw/tests/ui/invalid_assert_variable.stderr
@@ -1,17 +1,29 @@
 error[E0425]: cannot find value `does_not_exist` in this scope
- --> $DIR/invalid_assert_variable.rs:4:13
+ --> tests/ui/invalid_assert_variable.rs:4:13
   |
 4 | #[br(assert(does_not_exist == 0))]
   |             ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `a` in this scope
-  --> $DIR/invalid_assert_variable.rs:11:13
+  --> tests/ui/invalid_assert_variable.rs:11:13
    |
 11 | #[br(assert(a == 0))]
-   |             ^ help: a local variable with a similar name exists: `b`
+   |             ^
+   |
+help: a local variable with a similar name exists
+   |
+11 - #[br(assert(a == 0))]
+11 + #[br(assert(b == 0))]
+   |
 
 error[E0425]: cannot find value `a` in this scope
-  --> $DIR/invalid_assert_variable.rs:21:17
+  --> tests/ui/invalid_assert_variable.rs:21:17
    |
 21 |     #[br(assert(a == 0))]
-   |                 ^ help: a local variable with a similar name exists: `b`
+   |                 ^
+   |
+help: a local variable with a similar name exists
+   |
+21 -     #[br(assert(a == 0))]
+21 +     #[br(assert(b == 0))]
+   |

--- a/binrw/tests/ui/invalid_err_context_args.stderr
+++ b/binrw/tests/ui/invalid_err_context_args.stderr
@@ -6,6 +6,11 @@ error: multiple unused formatting arguments
   |                      |      |
   |                      |      argument never used
   |                      multiple missing formatting specifiers
+  |
+help: format specifiers use curly braces, consider adding 2 format specifiers
+  |
+5 |     #[br(err_context("too{}{}", "many", "arguments"))]
+  |                          ++++
 
 error: err_context requires a value but none were given
   --> tests/ui/invalid_err_context_args.rs:11:10

--- a/binrw/tests/ui/invalid_offset_type.stderr
+++ b/binrw/tests/ui/invalid_offset_type.stderr
@@ -13,6 +13,6 @@ note: method defined here
   |     pub offset: u64,
   |         ^^^^^^
 help: you can convert a `u8` to a `u64`
-    |
-6   |     #[br(offset = a.into())]
-    |                    +++++++
+  |
+6 |     #[br(offset = a.into())]
+  |                    +++++++

--- a/binrw/tests/ui/unsupported_type_union.stderr
+++ b/binrw/tests/ui/unsupported_type_union.stderr
@@ -1,5 +1,5 @@
 error: unions are not supported
- --> $DIR/unsupported_type_union.rs:4:1
+ --> tests/ui/unsupported_type_union.rs:4:1
   |
 4 | / union Foo {
 5 | |     a: i32,
@@ -7,9 +7,9 @@ error: unions are not supported
   | |_^
 
 error: unions are not supported
-  --> $DIR/unsupported_type_union.rs:9:1
+  --> tests/ui/unsupported_type_union.rs:9:1
    |
-9  | / union Bar {
+ 9 | / union Bar {
 10 | |     a: i32,
 11 | | }
    | |_^

--- a/binrw_derive/src/binrw/codegen/sanitization.rs
+++ b/binrw_derive/src/binrw/codegen/sanitization.rs
@@ -1,5 +1,5 @@
 //! Utilities for helping sanitize macro
-use crate::util::{from_crate, ident_str};
+use crate::util::{from_crate, ident_str, IdentStr};
 use proc_macro2::Ident;
 use quote::format_ident;
 
@@ -34,11 +34,6 @@ ident_str! {
     pub(crate) ENDIAN_ENUM = from_crate!(Endian);
     pub(crate) READ_METHOD = from_read_trait!(read_options);
     pub(crate) WRITE_METHOD = from_write_trait!(write_options);
-    pub(crate) READER = "__binrw_generated_var_reader";
-    pub(crate) WRITER = "__binrw_generated_var_writer";
-    pub(crate) OPT = "__binrw_generated_var_endian";
-    pub(crate) ARGS = "__binrw_generated_var_arguments";
-    pub(crate) SAVED_POSITION = "__binrw_generated_saved_position";
     pub(crate) NOT_ENOUGH_BYTES = from_crate!(__private::not_enough_bytes);
     pub(crate) ASSERT_MAGIC = from_crate!(__private::magic);
     pub(crate) ASSERT = from_crate!(__private::assert);
@@ -68,19 +63,28 @@ ident_str! {
     pub(crate) WRITE_MAGIC = from_crate!(meta::WriteMagic);
     pub(crate) WITH_CONTEXT = from_crate!(error::ContextExt::with_context);
     pub(crate) BACKTRACE_FRAME = from_crate!(error::BacktraceFrame);
-    pub(crate) TEMP = "__binrw_temp";
-    pub(crate) THIS = "__binrw_this";
-    pub(crate) POS = "__binrw_generated_position_temp";
-    pub(crate) ERROR_BASKET = "__binrw_generated_error_basket";
-    pub(crate) READ_FUNCTION = "__binrw_generated_read_function";
-    pub(crate) WRITE_FUNCTION = "__binrw_generated_write_function";
-    pub(crate) BEFORE_POS = "__binrw_generated_before_pos";
-    pub(crate) ALL_EOF = "__binrw_generated_all_eof";
     pub(crate) BOX = from_crate!(__private::Box);
     pub(crate) DBG_EPRINTLN = from_crate!(__private::eprintln);
     pub(crate) FORMAT = from_crate!(__private::format);
     pub(crate) VEC = from_crate!(__private::Vec);
 }
+
+pub(crate) const READER: IdentStr = IdentStr::new_hygienic("__binrw_generated_var_reader");
+pub(crate) const WRITER: IdentStr = IdentStr::new_hygienic("__binrw_generated_var_writer");
+pub(crate) const OPT: IdentStr = IdentStr::new_hygienic("__binrw_generated_var_endian");
+pub(crate) const ARGS: IdentStr = IdentStr::new_hygienic("__binrw_generated_var_arguments");
+pub(crate) const SAVED_POSITION: IdentStr =
+    IdentStr::new_hygienic("__binrw_generated_saved_position");
+pub(crate) const TEMP: IdentStr = IdentStr::new_hygienic("__binrw_temp");
+pub(crate) const THIS: IdentStr = IdentStr::new_hygienic("__binrw_this");
+pub(crate) const POS: IdentStr = IdentStr::new_hygienic("__binrw_generated_position_temp");
+pub(crate) const ERROR_BASKET: IdentStr = IdentStr::new_hygienic("__binrw_generated_error_basket");
+pub(crate) const READ_FUNCTION: IdentStr =
+    IdentStr::new_hygienic("__binrw_generated_read_function");
+pub(crate) const WRITE_FUNCTION: IdentStr =
+    IdentStr::new_hygienic("__binrw_generated_write_function");
+pub(crate) const BEFORE_POS: IdentStr = IdentStr::new_hygienic("__binrw_generated_before_pos");
+pub(crate) const ALL_EOF: IdentStr = IdentStr::new_hygienic("__binrw_generated_all_eof");
 
 pub(crate) fn make_ident(ident: &Ident, kind: &str) -> Ident {
     format_ident!("__binrw_generated_{}_{}", kind, ident)

--- a/binrw_derive/src/binrw/parser/field_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/field_level_attrs.rs
@@ -145,16 +145,17 @@ impl StructField {
     fn validate(&self, options: Options) -> syn::Result<()> {
         let mut all_errors = None::<syn::Error>;
 
-        if self.do_try.is_some() && self.generated_value() {
-            //TODO: join with span of read mode somehow
-            let span = self.do_try.as_ref().unwrap().span();
-            combine_error(
-                &mut all_errors,
-                syn::Error::new(
-                    span,
-                    "`try` is incompatible with `default`, `calc`, and `try_calc`",
-                ),
-            );
+        if self.generated_value() {
+            if let Some(do_try) = &self.do_try {
+                //TODO: join with span of read mode somehow
+                combine_error(
+                    &mut all_errors,
+                    syn::Error::new(
+                        do_try.span(),
+                        "`try` is incompatible with `default`, `calc`, and `try_calc`",
+                    ),
+                );
+            }
         }
 
         if !options.write

--- a/binrw_derive/src/binrw/parser/types/cond_endian.rs
+++ b/binrw_derive/src/binrw/parser/types/cond_endian.rs
@@ -32,17 +32,12 @@ impl ToTokens for Endian {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum CondEndian {
+    #[default]
     Inherited,
     Fixed(Endian),
     Cond(Endian, TokenStream),
-}
-
-impl Default for CondEndian {
-    fn default() -> Self {
-        Self::Inherited
-    }
 }
 
 impl From<attrs::Big> for CondEndian {

--- a/binrw_derive/src/binrw/parser/types/enum_error_mode.rs
+++ b/binrw_derive/src/binrw/parser/types/enum_error_mode.rs
@@ -3,17 +3,12 @@ use crate::{
     meta_types::KeywordToken,
 };
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub(crate) enum EnumErrorMode {
+    #[default]
     Default,
     ReturnAllErrors,
     ReturnUnexpectedError,
-}
-
-impl Default for EnumErrorMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl From<attrs::ReturnAllErrors> for EnumErrorMode {

--- a/binrw_derive/src/binrw/parser/types/field_mode.rs
+++ b/binrw_derive/src/binrw/parser/types/field_mode.rs
@@ -5,19 +5,14 @@ use crate::{
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum FieldMode {
+    #[default]
     Normal,
     Default,
     Calc(TokenStream),
     TryCalc(TokenStream),
     Function(TokenStream),
-}
-
-impl Default for FieldMode {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 impl From<attrs::Ignore> for FieldMode {

--- a/binrw_derive/src/binrw/parser/types/map.rs
+++ b/binrw_derive/src/binrw/parser/types/map.rs
@@ -7,8 +7,9 @@ use quote::ToTokens;
 
 // Lint: Makes code less clear
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum Map {
+    #[default]
     None,
     Map(TokenStream),
     Try(TokenStream),
@@ -33,12 +34,6 @@ impl Map {
 
     pub(crate) fn is_try(&self) -> bool {
         matches!(self, Self::Try(_) | Self::Repr(_))
-    }
-}
-
-impl Default for Map {
-    fn default() -> Self {
-        Self::None
     }
 }
 

--- a/binrw_derive/src/named_args/codegen.rs
+++ b/binrw_derive/src/named_args/codegen.rs
@@ -227,11 +227,16 @@ impl Builder<'_> {
                 }
             });
 
-            let field_names = {
-                let names = self.fields.iter().map(|field| &field.name);
-                quote! { #( #names, )* }
-            };
             let field_name = &field.name;
+            let destructured_fields = self.fields.iter().map(|field| {
+                let name = &field.name;
+                if name == field_name {
+                    quote!(#name: _)
+                } else {
+                    quote!(#name)
+                }
+            });
+            let rebuilt_fields = self.fields.iter().map(|field| &field.name);
             let ty = &field.ty;
             let docs = format!("Sets `{field_name}` to the given value.");
 
@@ -253,14 +258,14 @@ impl Builder<'_> {
                         self, val: #ty
                     ) -> #builder_name < #user_generic_args #( #resulting_generics ),* > {
                         let #builder_name {
-                            #field_names
+                            #( #destructured_fields, )*
                             ..
                         } = self;
 
                         let #field_name = #field_result;
 
                         #builder_name {
-                            #field_names
+                            #( #rebuilt_fields, )*
                             __bind_generics: ::core::marker::PhantomData
                         }
                     }

--- a/binrw_derive/src/util.rs
+++ b/binrw_derive/src/util.rs
@@ -36,20 +36,44 @@ impl<T: ToTokens> ToSpannedTokens for &T {
 /// A string wrapper that converts the str to a $path `TokenStream`, allowing
 /// for constant-time idents that can be shared across threads
 #[derive(Clone, Copy)]
-pub(crate) struct IdentStr(&'static str);
+pub(crate) struct IdentStr {
+    str: &'static str,
+    generated_hygienic_ident: bool,
+}
 
 impl IdentStr {
     #[cfg_attr(coverage_nightly, coverage(off))] // const-only function
     pub(crate) const fn new(str: &'static str) -> Self {
-        IdentStr(str)
+        IdentStr {
+            str,
+            generated_hygienic_ident: false,
+        }
+    }
+
+    #[cfg_attr(coverage_nightly, coverage(off))] // const-only function
+    pub(crate) const fn new_hygienic(str: &'static str) -> Self {
+        IdentStr {
+            str,
+            generated_hygienic_ident: true,
+        }
     }
 
     pub(crate) fn iter(&self, span: Span) -> impl Iterator<Item = Ident> + '_ {
-        self.0.split("::").map(move |ident| Ident::new(ident, span))
+        self.str
+            .split("::")
+            .map(move |ident| Ident::new(ident, span))
     }
 
     pub(crate) fn to_ident(self, span: Span) -> Ident {
-        Ident::new(self.0, span)
+        Ident::new(self.str, self.hygienic_span(span))
+    }
+
+    fn hygienic_span(&self, span: Span) -> Span {
+        if self.generated_hygienic_ident {
+            Span::call_site()
+        } else {
+            span
+        }
     }
 }
 
@@ -61,6 +85,7 @@ impl ToTokens for IdentStr {
 
 impl ToSpannedTokens for IdentStr {
     fn to_spanned_tokens(&self, tokens: &mut TokenStream, span: Span) {
+        let span = self.hygienic_span(span);
         tokens.append_separated(self.iter(span), quote::quote_spanned!(span=> ::));
     }
 }


### PR DESCRIPTION
This PR fixes a bug where deriving `BinRead`/`BinWrite` through a macro-expanded derive path could error in attributes like `#[br(pre_assert(...))]` with `error[E0425]: cannot find value __binrw_generated_position_temp in this scope`, `help: an identifier with the same name is defined here, but is not accessible due to macro hygiene`. This was revealed when I tried using [derive-aliases](https://github.com/nik-rev/derive-aliases), but it can happen with normal `macro_rules!`, see the tests. This PR makes the `__binrw_generated_position_temp`-style `IdentStr`s use `Span::call_site()` in `to_ident` and `to_spanned_tokens` while leaving the span untouched for other `IdentStr`s, which fixes the error for me. If there is another way you want this issue solved, I can rework it.

Also, I considered adding something like this to simplify the sanitization file:
```rust
ident_str! {
    pub(crate) hygienic POS = "__binrw_generated_position_temp";
}
```
But it seemed like overkill for a couple of identifiers. Let me know if you want me to put that back in or do something else.

Long-term, I think we should be more careful with spans; I saw some TODOs related to this. Even then, it's probably a good idea to keep these changes.

Finally, I fixed some new warnings and clippy lints to keep CI happy, but the nightly UI tests will probably still fail.