### PR TITLE
Fix future incompatibility

### DIFF
--- a/binrw/src/binread/mod.rs
+++ b/binrw/src/binread/mod.rs
@@ -1,10 +1,10 @@
 mod impls;
 
 use crate::{
-    io::{Read, Seek},
-    BinResult, Endian,
     __private::Required,
+    io::{Read, Seek},
     meta::ReadEndian,
+    BinResult, Endian,
 };
 pub use impls::VecArgs;
 

--- a/binrw/src/binwrite/mod.rs
+++ b/binrw/src/binwrite/mod.rs
@@ -1,9 +1,9 @@
 mod impls;
 
 use crate::{
+    __private::Required,
     io::{Seek, Write},
     BinResult, Endian,
-    __private::Required,
 };
 
 /// The `BinWrite` trait serialises objects and writes them to streams.

--- a/binrw/src/lib.rs
+++ b/binrw/src/lib.rs
@@ -336,7 +336,7 @@ pub mod prelude {
     //! use binrw::prelude::*;
     //! ```
 
-    pub use crate::{
-        binread, binrw, binwrite, BinRead, BinReaderExt, BinResult, BinWrite, BinWriterExt,
-    };
+    pub use crate::{binread, binwrite, BinRead, BinReaderExt, BinResult, BinWrite, BinWriterExt};
+    pub extern crate self as binrw;
+    pub use binrw_derive::binrw;
 }

--- a/binrw_derive/src/binrw/codegen/read_options/enum.rs
+++ b/binrw_derive/src/binrw/codegen/read_options/enum.rs
@@ -232,7 +232,7 @@ fn generate_variant_impl(en: &Enum, variant: &EnumVariant) -> TokenStream {
         EnumVariant::Variant { ident, options } => StructGenerator::new(&input, options)
             .read_fields(
                 None,
-                Some(&format!("{}::{}", en.ident.as_ref().unwrap(), &ident)),
+                Some(&format!("{}::{}", en.ident.as_ref().unwrap(), ident)),
             )
             .initialize_value_with_assertions(Some(ident), &en.assertions)
             .return_value()

--- a/binrw_derive/src/binrw/parser/field_level_attrs.rs
+++ b/binrw_derive/src/binrw/parser/field_level_attrs.rs
@@ -145,16 +145,18 @@ impl StructField {
     fn validate(&self, options: Options) -> syn::Result<()> {
         let mut all_errors = None::<syn::Error>;
 
-        if self.do_try.is_some() && self.generated_value() {
-            //TODO: join with span of read mode somehow
-            let span = self.do_try.as_ref().unwrap().span();
-            combine_error(
-                &mut all_errors,
-                syn::Error::new(
-                    span,
-                    "`try` is incompatible with `default`, `calc`, and `try_calc`",
-                ),
-            );
+        if let Some(do_try) = &self.do_try {
+            if self.generated_value() {
+                //TODO: join with span of read mode somehow
+                let span = do_try.span();
+                combine_error(
+                    &mut all_errors,
+                    syn::Error::new(
+                        span,
+                        "`try` is incompatible with `default`, `calc`, and `try_calc`",
+                    ),
+                );
+            }
         }
 
         if !options.write

--- a/binrw_derive/src/binrw/parser/types/cond_endian.rs
+++ b/binrw_derive/src/binrw/parser/types/cond_endian.rs
@@ -32,17 +32,12 @@ impl ToTokens for Endian {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum CondEndian {
+    #[default]
     Inherited,
     Fixed(Endian),
     Cond(Endian, TokenStream),
-}
-
-impl Default for CondEndian {
-    fn default() -> Self {
-        Self::Inherited
-    }
 }
 
 impl From<attrs::Big> for CondEndian {

--- a/binrw_derive/src/binrw/parser/types/enum_error_mode.rs
+++ b/binrw_derive/src/binrw/parser/types/enum_error_mode.rs
@@ -3,17 +3,12 @@ use crate::{
     meta_types::KeywordToken,
 };
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub(crate) enum EnumErrorMode {
+    #[default]
     Default,
     ReturnAllErrors,
     ReturnUnexpectedError,
-}
-
-impl Default for EnumErrorMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl From<attrs::ReturnAllErrors> for EnumErrorMode {

--- a/binrw_derive/src/binrw/parser/types/field_mode.rs
+++ b/binrw_derive/src/binrw/parser/types/field_mode.rs
@@ -5,19 +5,14 @@ use crate::{
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum FieldMode {
+    #[default]
     Normal,
     Default,
     Calc(TokenStream),
     TryCalc(TokenStream),
     Function(TokenStream),
-}
-
-impl Default for FieldMode {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 impl From<attrs::Ignore> for FieldMode {

--- a/binrw_derive/src/binrw/parser/types/magic.rs
+++ b/binrw_derive/src/binrw/parser/types/magic.rs
@@ -75,7 +75,7 @@ impl TryFrom<attrs::Magic> for SpannedValue<Inner> {
                 if i.suffix().is_empty() {
                     return Err(syn::Error::new(
                         value.span(),
-                        format!("expected explicit type suffix for integer literal\ne.g {i}u64",),
+                        format!("expected explicit type suffix for integer literal\ne.g {i}u64"),
                     ));
                 }
                 Kind::Numeric(i.suffix().to_owned())

--- a/binrw_derive/src/binrw/parser/types/map.rs
+++ b/binrw_derive/src/binrw/parser/types/map.rs
@@ -7,8 +7,9 @@ use quote::ToTokens;
 
 // Lint: Makes code less clear
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum Map {
+    #[default]
     None,
     Map(TokenStream),
     Try(TokenStream),
@@ -33,12 +34,6 @@ impl Map {
 
     pub(crate) fn is_try(&self) -> bool {
         matches!(self, Self::Try(_) | Self::Repr(_))
-    }
-}
-
-impl Default for Map {
-    fn default() -> Self {
-        Self::None
     }
 }
 

--- a/binrw_derive/src/result.rs
+++ b/binrw_derive/src/result.rs
@@ -54,10 +54,9 @@ impl<T, E: core::fmt::Debug> PartialResult<T, E> {
         match self {
             PartialResult::Ok(value) => (value, None),
             PartialResult::Partial(value, error) => (value, Some(error)),
-            PartialResult::Err(error) => panic!(
-                "called `PartialResult::unwrap_tuple()` on an `Err` value: {:?}",
-                &error
-            ),
+            PartialResult::Err(error) => {
+                panic!("called `PartialResult::unwrap_tuple()` on an `Err` value: {error:?}")
+            }
         }
     }
 }


### PR DESCRIPTION
On nightly I'm getting this error (which is surfaced as a warning in reverse-dependencies):
```
Error[E0365]: extern crate `binrw` is private and cannot be re-exported
   --> binrw/src/lib.rs:340:18
    |
340 |         binread, binrw, binwrite, BinRead, BinReaderExt, BinResult, BinWrite, BinWriterExt,
    |                  ^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
    = note: `#[deny(pub_use_of_private_extern_crate)]` (part of `#[deny(future_incompatible)]`) on by default
help: consider making the `extern crate` item publicly accessible
    |
 16 | pub extern crate self as binrw;
    | +++

For more information about this error, try `rustc --explain E0365`.
error: could not compile `binrw` (lib) due to 2 previous errors
```

This can be fixed by using 
```rs
pub extern crate self as binrw;
pub use binrw_derive::binrw;
```
instead.

Also fixes some clippy lints and does cargo fmt while I'm at it.