### PR TITLE
 Harden parsers against untrusted-input DoS and panics

### DIFF
--- a/binrw/src/file_ptr.rs
+++ b/binrw/src/file_ptr.rs
@@ -336,7 +336,7 @@ where
         let relative_to = args.offset;
         let before = reader.stream_position()?;
         reader.seek(SeekFrom::Start(relative_to))?;
-        reader.seek(ptr.into_seek_from())?;
+        reader.seek(ptr.into_seek_from()?)?;
         let value = parser(reader, endian, args.inner);
         reader.seek(SeekFrom::Start(before))?;
         value
@@ -528,7 +528,7 @@ where
                 // 2. Seeks that change the position when it does not need
                 //    to change may unnecessarily flush a buffered reader
                 //    cache.
-                match ptr.into_seek_from() {
+                match ptr.into_seek_from()? {
                     seek @ SeekFrom::Current(offset) => {
                         if let Some(new_pos) = base_pos.checked_add_signed(offset) {
                             if new_pos != reader.stream_position()? {
@@ -552,15 +552,26 @@ where
 /// A trait to convert from an integer into [`SeekFrom::Current`].
 pub trait IntoSeekFrom: Copy {
     /// Converts the value.
-    fn into_seek_from(self) -> SeekFrom;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value cannot be represented as an [`i64`]
+    /// (e.g. a `u64`/`u128` offset larger than [`i64::MAX`] read from input).
+    fn into_seek_from(self) -> BinResult<SeekFrom>;
 }
 
 macro_rules! impl_into_seek_from {
     ($($t:ty),*) => {
         $(
             impl IntoSeekFrom for $t {
-                fn into_seek_from(self) -> SeekFrom {
-                    SeekFrom::Current(TryInto::try_into(self).unwrap())
+                fn into_seek_from(self) -> BinResult<SeekFrom> {
+                    let offset = TryInto::try_into(self).map_err(|_| {
+                        crate::Error::Io(crate::io::Error::new(
+                            crate::io::ErrorKind::InvalidInput,
+                            "file pointer offset out of range for `SeekFrom::Current`",
+                        ))
+                    })?;
+                    Ok(SeekFrom::Current(offset))
                 }
             }
         )*
@@ -573,7 +584,7 @@ macro_rules! impl_into_seek_from_for_non_zero {
     ($($t:ty),*) => {
         $(
             impl IntoSeekFrom for $t {
-                fn into_seek_from(self) -> SeekFrom {
+                fn into_seek_from(self) -> BinResult<SeekFrom> {
                     self.get().into_seek_from()
                 }
             }

--- a/binrw/src/io/take_seek.rs
+++ b/binrw/src/io/take_seek.rs
@@ -64,7 +64,7 @@ impl<T: Seek> TakeSeek<T> {
             .stream_position()
             .expect("cannot get position for `set_limit`");
         self.pos = pos;
-        self.end = pos + limit;
+        self.end = pos.saturating_add(limit);
     }
 }
 
@@ -118,6 +118,10 @@ impl<T: Seek> Seek for TakeSeek<T> {
 pub trait TakeSeekExt {
     /// Creates an adapter which will read at most `limit` bytes from the
     /// wrapped stream.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner stream returns an error from `stream_position`.
     fn take_seek(self, limit: u64) -> TakeSeek<Self>
     where
         Self: Sized;
@@ -135,7 +139,7 @@ impl<T: Read + Seek> TakeSeekExt for T {
         TakeSeek {
             inner: self,
             pos,
-            end: pos + limit,
+            end: pos.saturating_add(limit),
         }
     }
 }

--- a/binrw/src/punctuated.rs
+++ b/binrw/src/punctuated.rs
@@ -81,8 +81,11 @@ where
     where
         T::Args<'a>: Clone,
     {
-        let mut data = Vec::with_capacity(args.count);
-        let mut separators = Vec::with_capacity(args.count.max(1) - 1);
+        // Note: capacity is intentionally not pre-reserved from `args.count`
+        // because the count comes from untrusted input and a malicious value
+        // could trigger a huge allocation before any element is read.
+        let mut data = Vec::new();
+        let mut separators = Vec::new();
 
         for i in 0..args.count {
             data.push(T::read_options(reader, endian, args.inner.clone())?);
@@ -107,8 +110,11 @@ where
     where
         T::Args<'a>: Clone,
     {
-        let mut data = Vec::with_capacity(args.count);
-        let mut separators = Vec::with_capacity(args.count);
+        // Note: capacity is intentionally not pre-reserved from `args.count`
+        // because the count comes from untrusted input and a malicious value
+        // could trigger a huge allocation before any element is read.
+        let mut data = Vec::new();
+        let mut separators = Vec::new();
 
         for _ in 0..args.count {
             data.push(T::read_options(reader, endian, args.inner.clone())?);


### PR DESCRIPTION
  binrw parses untrusted binary data, but a few paths could be driven to
  OOM or panic by a malicious file. Align them with the hardening patterns
  already used elsewhere in the crate.

  - punctuated: drop `Vec::with_capacity(count)` in `separated` and `separated_trailing`. `count` is attacker-controlled, so a huge value forced a multi-GB allocation before reading any element. Let the Vec grow as elements are successfully read, like `helpers::count`.

  - file_ptr: make `IntoSeekFrom::into_seek_from` return `BinResult` instead of `unwrap()`-ing the `i64` conversion. A `FilePtr64`/ `FilePtr128` offset larger than `i64::MAX` now yields an `Io(InvalidInput)` error instead of panicking.

  - take_seek: use `saturating_add` for `pos + limit` in `set_limit` and `take_seek` to avoid overflow (debug panic / release wrap to a false EOF) when `limit` is large.

  - take_seek: document the `stream_position` panic on the `take_seek` trait method, matching `set_limit`.