### PR TITLE
docs: clarify write-side padding behavior

### DIFF
--- a/binrw/doc/attribute.md
+++ b/binrw/doc/attribute.md
@@ -1996,6 +1996,13 @@ parsing started.
 binrw includes directives for common forms of
 [data structure alignment](https://en.wikipedia.org/wiki/Data_structure_alignment#Data_structure_padding).
 
+When reading, `pad_before`, `pad_after`, `align_before`, `align_after`, and
+`pad_size_to` advance the reader by seeking over bytes. When writing, they write
+zeroes to advance the writer and therefore overwrite any existing bytes in the
+padded region. To leave existing bytes untouched, use
+[`seek_before`](#padding-and-alignment) with an appropriate
+[`SeekFrom`](crate::io::SeekFrom) value instead.
+
 The `pad_before` and `pad_after` directives skip a specific number of bytes
 either before or after
 <span class="br">reading</span><span class="bw">writing</span> a field,


### PR DESCRIPTION
## Summary

- document that write-side padding and alignment directives fill skipped bytes with zeroes
- distinguish that behavior from read-side seeking
- point users to `seek_before` when existing bytes must remain untouched

## Validation

- `cargo test --doc` (123 passed)
- `cargo test`
- `cargo clippy --all-targets --no-default-features` (only existing warnings in unchanged files)
- `git diff --check`

Closes #295
